### PR TITLE
Additional CommerceHub APIs

### DIFF
--- a/FiservTTP.podspec
+++ b/FiservTTP.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name = 'FiservTTP'
-  s.version = '0.1.1'
+  s.version = '0.1.3'
   s.license = { :type => 'MIT', :file => 'LICENSE' }
   s.summary = 'Tap To Pay on iPhone by Fiserv'
   s.homepage = 'https://github.com/Fiserv/TTPPackage'

--- a/README.md
+++ b/README.md
@@ -120,10 +120,6 @@ do {
 ### Is Account Linked
 When targeting iOS 16.4 or greater, the option to check if the account is already linked is available.
 
-Additional information can be found here:
-
-[isAccountLinked](https://developer.apple.com/documentation/proximityreader/paymentcardreader/isaccountlinked\(using:\))
-
 ```Swift
 do {
     let isLinked = try await fiservTTPCardReader.isAccountLinked()
@@ -132,6 +128,9 @@ do {
 }
 ```
 
+Additional information can be found here:
+
+[isAccountLinked](https://developer.apple.com/documentation/proximityreader/paymentcardreader/isaccountlinked\(using:\))
 
 ### Initialize the Card Reader Session
 Now you're ready to initialize the Apple Proximity Reader by calling:

--- a/README.md
+++ b/README.md
@@ -84,22 +84,27 @@ Early in the startup process of your app, call the following method to validate 
 
 ```Swift
 if !fiservTTPCardReader.readerIsSupported() {
-    ///TODO handle unsupported device
+    // TODO handle unsupported device
 }
 ```
 
 ### Obtain PSP Token
+
+Additional information can be found here:
+
+[Commerce Hub Inquire](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Security/Credentials.md&branch=main#endpoint)
+
 You must obtain a session token in order to utilize the SDK.  Acquire the token by making this call:
 
 ```Swift
 do {
     try await fiservTTPCardReader.requestSessionToken()
 } catch let error as FiservTTPCardReaderError {
-    ///TODO handle exception
+    // TODO handle exception
 }
 ```
 
-Note that the session token will expire in 24 hours.  You are responsible for keeping track of when to obtain a new token.
+Note that the session token has a time to live of 48 hours. However, we have included an **auto-refresh feature** that will request a new token for you when the TTL value is 30 minutes or less. Moving the app from the background to the foreground, as well as unlocking (a locked iPhone) will trigger this check and the refresh will occur based on the time remaining of the token. 
 
 ### Link Account
 Next you must link the device running the app to an Apple ID. This needs to happen **just once**.  You are responsible for tracking whether the linking process has occurred already or not.  If not, then perform linking by making this call:
@@ -108,25 +113,45 @@ Next you must link the device running the app to an Apple ID. This needs to happ
 do {
     try await fiservTTPCardReader.linkAcount()
 } catch let error as FiservTTPCardReaderError {
-    ///TODO handle exception
+    // TODO handle exception
 }
 ```
+
+### Is Account Linked
+When targeting iOS 16.4 or greater, the option to check if the account is already linked is available.
+
+Additional information can be found here:
+
+[isAccountLinked](https://developer.apple.com/documentation/proximityreader/paymentcardreader/isaccountlinked\(using:\))
+
+```Swift
+do {
+    let isLinked = try await fiservTTPCardReader.isAccountLinked()
+} catch let error as FiservTTPCardReaderError {
+    // TODO handle exception
+}
+```
+
 
 ### Initialize the Card Reader Session
 Now you're ready to initialize the Apple Proximity Reader by calling:
 
 ```Swift
 do {
-    try await self.fiservTTPCardReader.initializeSession()
+    try await fiservTTPCardReader.initializeSession()
 } catch let error as FiservTTPCardReaderError {
-    ///TODO handle exception
+    // TODO handle exception
 }
 ```
 
-**NOTE** that you must re-initialize the reader session each time the app starts and/or returns to the foreground!
+**NOTE:** that you must re-initialize the reader session each time the app starts.
 
-### Take a Payment
+### Take a Payment (Charges)
 Congrats on getting this far!  Now you are ready to process your first payment.  Simply make this call and the SDK takes care of the rest for you:
+
+Additional information can be found here:
+
+[Commerce Hub Charges](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Charges.md&branch=main)
 
 ```Swift
 let amount = 10.99  // amount to charge
@@ -134,42 +159,91 @@ let merchantOrderId = "your order ID, for tracking purposes"
 let merchantTransactionId = "your transaction ID, for tracking purposes"
 
 do {
-    let chargeResponse = try await readCard(
-        amount: amount, 
-        merchantOrderId: merchantOrderId, 
-        merchantTransactionId: merchantTransactionId)
-    ///TODO inspect the chargeResponse to see the authorization result
+    let chargeResponse = try await fiservTTPCardReader.readCard(amount: amount, 
+                                                                merchantOrderId: merchantOrderId, 
+                                                                merchantTransactionId: merchantTransactionId)
+    // TODO inspect the chargeResponse to see the authorization result
 } catch let error as FiservTTPCardReaderError {
-    ///TODO handle exception
+    // TODO handle exception
 }
 ```
-### Void a Payment
+
+### Inquiry
+
+Additional information can be found here:
+
+[Commerce Hub Inquiry](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Inquiry.md&branch=main)
+
+**NOTE:** At least one of the arguments must be provided.
+
+```Swift
+do {
+    let inquireResponse = try await fiservTTPCardReader.inquiryTransaction(referenceTransactionId: referenceTransactionId,
+                                                                           referenceMerchantTransactionId: referenceMerchantTransactionId,
+                                                                           referenceMerchantOrderId: referenceMerchantOrderId,
+                                                                           referenceOrderId: referenceOrderId)
+    // TODO inspect the Inquire Response to see the result
+} catch let error as FiservTTPCardReaderError {
+    // TODO handle exception
+}
+```
+
+### Cancel a Payment
+
+Additional information can be found here:
+
+[Commerce Hub Cancel](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Cancel.md&branch=main)
 
 ```Swift
 let amount = 10.99 // amount to void
 let referenceTransactionId = "this value was returned in the charge response"
 do {
-  let voidResponse = try await voidTransaction(
-      amount:amount,
-      referenceTransactionId = referenceTransactionId)
-    ///TODO inspect the voidResponse to see the result   
+  let voidResponse = try await fiservTTPCardReader.voidTransaction(amount:amount,
+                                                                   referenceTransactionId = referenceTransactionId)\
+    // TODO inspect the voidResponse to see the result
 } catch let error as FiservTTPCardReaderError {
-    ///TODO handle exception
+    // TODO handle exception
 }
 ```
-### Refund a Payment
+### Refund a Payment without Tap
+
+Additional information can be found here:
+
+[Commerce Hub Matched Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Tagged.md&branch=main)
 
 ```Swift
 let amount = 10.99 // amount to void
 let referenceTransactionId = "this value was returned in the charge response"
 do {
-  let refundResponse = try await refundTransaction(
-      amount:amount,
-      referenceTransactionId = referenceTransactionId)
-    ///TODO inspect the refundResponse to see the result   
+  let refundResponse = try await fiservTTPCardReader.refundTransaction(amount:amount,
+                                                                       referenceTransactionId = referenceTransactionId)
+    // TODO inspect the refundResponse to see the result   
 } catch let error as FiservTTPCardReaderError {
-    ///TODO handle exception
+    // TODO handle exception
 }
+```
+
+### Refund a Payment with Tap (Unmatched Tagged Refund and Open Refund)
+
+**NOTE:** At least one of the following must be provided (referenceTransactionId, referenceMerchantTransactionId) to perform an unmatched tagged refund. If neither reference values are provided, an open refund be will performed. Amount is always required.
+
+Additional information can be found here:
+
+[Commerce Hub Unmatched Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Unmatched.md&branch=main)
+    
+[Commerce Hub Open Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Open.md&branch=main)
+
+```Swift
+let amount = 10.99 // amount to void
+let referenceTransactionId = "this value was returned in the charge response"
+do {
+    let refundResponse = try await fiservTTPCardReader.refundCard(amount: bankersAmount(amount: amount),
+                                                                  referenceTransactionId: referenceTransactionId,
+                                                                  referenceMerchantTransactionId: referenceMerchantTransactionId)
+    // TODO inspect the refundResponse to see the result
+} catch let error as FiservTTPCardReaderError {
+    // TODO handle exception
+}                                                                 
 ```
 
 ## Download the sample app

--- a/README.md
+++ b/README.md
@@ -90,10 +90,6 @@ if !fiservTTPCardReader.readerIsSupported() {
 
 ### Obtain PSP Token
 
-Additional information can be found here:
-
-[Commerce Hub Security](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Security/Credentials.md&branch=main#endpoint)
-
 You must obtain a session token in order to utilize the SDK.  Acquire the token by making this call:
 
 ```Swift
@@ -105,6 +101,10 @@ do {
 ```
 
 Note that the session token has a time to live of 48 hours. However, we have included an **auto-refresh feature** that will request a new token for you when the TTL value is 30 minutes or less. Moving the app from the background to the foreground, as well as unlocking (a locked iPhone) will trigger this check and the refresh will occur based on the time remaining of the token. 
+
+Additional information can be found here:
+
+[Commerce Hub Security](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Security/Credentials.md&branch=main#endpoint)
 
 ### Link Account
 Next you must link the device running the app to an Apple ID. This needs to happen **just once**.  You are responsible for tracking whether the linking process has occurred already or not.  If not, then perform linking by making this call:
@@ -149,10 +149,6 @@ do {
 ### Take a Payment (Charges)
 Congrats on getting this far!  Now you are ready to process your first payment.  Simply make this call and the SDK takes care of the rest for you:
 
-Additional information can be found here:
-
-[Commerce Hub Charges](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Charges.md&branch=main)
-
 ```Swift
 let amount = 10.99  // amount to charge
 let merchantOrderId = "your order ID, for tracking purposes"
@@ -167,11 +163,12 @@ do {
     // TODO handle exception
 }
 ```
-### Cancel a Payment
 
 Additional information can be found here:
 
-[Commerce Hub Cancel](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Cancel.md&branch=main)
+[Commerce Hub Charges](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Charges.md&branch=main)
+
+### Cancel a Payment
 
 ```Swift
 let amount = 10.99 // amount to void
@@ -184,11 +181,11 @@ do {
     // TODO handle exception
 }
 ```
-### Refund a Payment without Tap
-
 Additional information can be found here:
 
-[Commerce Hub Matched Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Tagged.md&branch=main)
+[Commerce Hub Cancel](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Cancel.md&branch=main)
+
+### Refund a Payment without Tap
 
 ```Swift
 let amount = 10.99 // amount to void
@@ -202,19 +199,15 @@ do {
 }
 ```
 
+Additional information can be found here:
+
+[Commerce Hub Matched Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Tagged.md&branch=main)
+
 ### Refund a Payment with Tap (Unmatched Tagged Refund and Open Refund)
 
 **NOTE:** At least one of the following must be provided (referenceTransactionId, referenceMerchantTransactionId) to perform an unmatched tagged refund. If neither reference values are provided, an open refund be will performed. Amount is always required.
 
-Additional information can be found here:
-
-[Commerce Hub Unmatched Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Unmatched.md&branch=main)
-
 An unmatched tagged refund allows a merchant to issue a refund to a payment source other than the one used in the original transaction. The refund is associated with the original charge request by using the Commerce Hub transaction identifier or merchant transaction identifier. This allows the merchant to maintain the linking of the transaction information in Commerce Hub when issuing a refund or store credit.
-
-    
-
-[Commerce Hub Open Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Open.md&branch=main)
 
 An open refund (credit) is a refund to a card without a reference to the prior transaction.
 
@@ -230,14 +223,15 @@ do {
     // TODO handle exception
 }                                                                 
 ```
+Additional information can be found here:
+
+[Commerce Hub Unmatched Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Unmatched.md&branch=main)
+
+[Commerce Hub Open Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Open.md&branch=main)
 
 ### Inquiry
 
 To retrieve the current state of any previous transaction, an inquiry request can be submitted against the Commerce Hub transaction identifier or merchant transaction identifier.
-
-Additional information can be found here:
-
-[Commerce Hub Inquiry](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Inquiry.md&branch=main)
 
 **NOTE:** At least one of the arguments must be provided.
 
@@ -252,6 +246,9 @@ do {
     // TODO handle exception
 }
 ```
+Additional information can be found here:
+
+[Commerce Hub Inquiry](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Inquiry.md&branch=main)
 
 ## Download the sample app
 We've prepared an end-to-end sample app to get you up and running fast. [Get the Sample App here](https://github.com/Fiserv/TTPSampleApp)

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ if !fiservTTPCardReader.readerIsSupported() {
 
 Additional information can be found here:
 
-[Commerce Hub Inquire](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Security/Credentials.md&branch=main#endpoint)
+[Commerce Hub Security](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Security/Credentials.md&branch=main#endpoint)
 
 You must obtain a session token in order to utilize the SDK.  Acquire the token by making this call:
 
@@ -167,27 +167,6 @@ do {
     // TODO handle exception
 }
 ```
-
-### Inquiry
-
-Additional information can be found here:
-
-[Commerce Hub Inquiry](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Inquiry.md&branch=main)
-
-**NOTE:** At least one of the arguments must be provided.
-
-```Swift
-do {
-    let inquireResponse = try await fiservTTPCardReader.inquiryTransaction(referenceTransactionId: referenceTransactionId,
-                                                                           referenceMerchantTransactionId: referenceMerchantTransactionId,
-                                                                           referenceMerchantOrderId: referenceMerchantOrderId,
-                                                                           referenceOrderId: referenceOrderId)
-    // TODO inspect the Inquire Response to see the result
-} catch let error as FiservTTPCardReaderError {
-    // TODO handle exception
-}
-```
-
 ### Cancel a Payment
 
 Additional information can be found here:
@@ -230,8 +209,14 @@ do {
 Additional information can be found here:
 
 [Commerce Hub Unmatched Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Unmatched.md&branch=main)
+
+An unmatched tagged refund allows a merchant to issue a refund to a payment source other than the one used in the original transaction. The refund is associated with the original charge request by using the Commerce Hub transaction identifier or merchant transaction identifier. This allows the merchant to maintain the linking of the transaction information in Commerce Hub when issuing a refund or store credit.
+
     
+
 [Commerce Hub Open Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Open.md&branch=main)
+
+An open refund (credit) is a refund to a card without a reference to the prior transaction.
 
 ```Swift
 let amount = 10.99 // amount to void
@@ -244,6 +229,28 @@ do {
 } catch let error as FiservTTPCardReaderError {
     // TODO handle exception
 }                                                                 
+```
+
+### Inquiry
+
+To retrieve the current state of any previous transaction, an inquiry request can be submitted against the Commerce Hub transaction identifier or merchant transaction identifier.
+
+Additional information can be found here:
+
+[Commerce Hub Inquiry](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Inquiry.md&branch=main)
+
+**NOTE:** At least one of the arguments must be provided.
+
+```Swift
+do {
+    let inquireResponse = try await fiservTTPCardReader.inquiryTransaction(referenceTransactionId: referenceTransactionId,
+                                                                           referenceMerchantTransactionId: referenceMerchantTransactionId,
+                                                                           referenceMerchantOrderId: referenceMerchantOrderId,
+                                                                           referenceOrderId: referenceOrderId)
+    // TODO inspect the Inquire Response to see the result
+} catch let error as FiservTTPCardReaderError {
+    // TODO handle exception
+}
 ```
 
 ## Download the sample app

--- a/Sources/FiservTTP/FiservTTPCardReader.swift
+++ b/Sources/FiservTTP/FiservTTPCardReader.swift
@@ -47,6 +47,8 @@ public class FiservTTPCardReader {
     
     private var token: String?
     
+    private var tokenExp: Double = 0.0
+    
     public var sessionReadySubject: PassthroughSubject<Bool, Never> = .init()
     
     /// Creates an instance of FiservTTPCardReader
@@ -87,13 +89,25 @@ public class FiservTTPCardReader {
     /// - Throws: An error of type FiservTTPCardReaderError
     ///
     public func requestSessionToken() async throws {
-        
+            
         let title = "Token Request"
         
         let result = await services.requestSessionToken()
         
+        self.token = nil
+        
+        self.tokenExp = 0
+        
         do {
-            self.token = try result.get().accessToken
+            
+            let jwtToken = try result.get().accessToken
+            
+            let tokenExpiration = try decode(jwtToken: jwtToken)["exp"] as? TimeInterval
+            
+            self.tokenExp = tokenExpiration ?? 0
+            
+            self.token = jwtToken
+            
         } catch {
             
             if let err = error as? FiservTTPRequestError {
@@ -106,6 +120,29 @@ public class FiservTTPCardReader {
                 throw FiservTTPCardReaderError(title: title,
                                                localizedDescription: NSLocalizedString("Unable to request a session token.", comment: ""))
             }
+        }
+    }
+    
+    /// A Boolean value that indicates whether the account is already linked.
+    ///
+    /// Call linkAccount(using:)  to link an account.
+    ///
+    /// If PaymentCardReader/prepare(using:) throws an PaymentCardReaderError/accountNotLinked error
+    /// call linkAccount(using:) again to relink the account.
+    ///
+    /// - Throws: An error of type FiservTTPCardReaderError
+    ///
+    @available(iOS 16.4, *)
+    public func isAccountLinked() async throws -> Bool {
+        
+        if let token = self.token {
+            
+            return try await self.fiservTTPReader.isAccountLinked(token: token)
+            
+        } else {
+            
+            throw FiservTTPCardReaderError(title: "Missing Token",
+                                           localizedDescription: NSLocalizedString("Unable to link this account, a token is required.", comment: ""))
         }
     }
     
@@ -140,9 +177,27 @@ public class FiservTTPCardReader {
     /// - Throws: An error of type FiservTTPCardReaderError
     ///
     public func initializeSession() async throws {
+            
+        if self.token != nil {
+            
+            // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+            // Check CommerceHub Token Expiration
+            // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+            let timestamp = Date().timeIntervalSince1970
+            
+            if self.tokenExp - timestamp < (300 - 180) { // 1800 { // 30 minutes
+                
+                try await requestSessionToken()   // Auto Refresh
+            }
+            
+        } else {
+            
+            throw FiservTTPCardReaderError(title: "Missing Token",
+                                           localizedDescription: NSLocalizedString("Unable to initialize the session, a token is required.", comment: ""))
+        }
         
         if let token = self.token {
-
+            
             try await self.fiservTTPReader.initializeSession(token: token, eventHandler: { event in
                 
                 if event == "notReady" {
@@ -153,7 +208,7 @@ public class FiservTTPCardReader {
             self.sessionReadySubject.send(true)
             
         } else {
-            
+
             throw FiservTTPCardReaderError(title: "Missing Token",
                                            localizedDescription: NSLocalizedString("Unable to initialize the session, a token is required.", comment: ""))
         }
@@ -209,6 +264,7 @@ public class FiservTTPCardReader {
         
         let result = try await self.fiservTTPReader.readCard(for: amount,
                                                              currencyCode: self.configuration.currencyCode,
+                                                             transactionType: .purchase,
                                                              eventHandler: { _ in
         })
         
@@ -251,6 +307,82 @@ public class FiservTTPCardReader {
         }
     }
     
+    /// Verify a transaction
+    ///
+    /// This method provides a way to lookup an existing transaction. At least one of the optional values must be provided.
+    ///
+    /// - Parameter referenceTransactionId: String
+    ///
+    /// - Parameter referenceMerchantTransactionId: String
+    ///
+    /// - Parameter referenceMerchantOrderId: String
+    ///
+    /// - Parameter referenceOrderId: String
+    ///
+    /// - Parameter referenceClientRequestId: String
+    ///
+    /// - Parameter tokenType: String
+    ///
+    /// - Parameter storeId: String
+    ///
+    /// - Parameter siteId: String
+    ///
+    /// - Returns:FiservTTPChargeResponse
+    ///
+    /// - Throws: An error of type FiservTTPCardReaderError
+    ///
+    public func inquiryTransaction(referenceTransactionId: String? = nil,
+                                   referenceMerchantTransactionId: String? = nil,
+                                   referenceMerchantOrderId: String? = nil,
+                                   referenceOrderId: String? = nil,
+                                   referenceClientRequestId: String? = nil,
+                                   tokenType: String? = nil,
+                                   storeId: String? = nil,
+                                   siteId: String? = nil) async throws -> [FiservTTPChargeResponse] {
+        
+        let title = "Inquiry Transaction"
+        
+        let inquiryResult = await services.inquiry(referenceTransactionId: referenceTransactionId,
+                                                   referenceMerchantTransactionId: referenceMerchantTransactionId,
+                                                   referenceMerchantOrderId: referenceMerchantOrderId,
+                                                   referenceOrderId: referenceOrderId,
+                                                   referenceClientRequestId: referenceClientRequestId,
+                                                   tokenType: tokenType,
+                                                   storeId: storeId,
+                                                   siteId: siteId)
+        
+        switch inquiryResult {
+            
+        case .success(let response):
+            
+            return response
+            
+        case .failure(let err):
+            
+            throw FiservTTPCardReaderError(title: title,
+                                           localizedDescription: err.localizedDescription,
+                                           failureReason: err.failureReason)
+        }
+    }
+    
+    /// Void a transaction
+    ///
+    /// This method provides a way to void an existing transaction. At least one of the optional values must be provided.
+    ///
+    /// - Parameter amount: Decimal
+    ///
+    /// - Parameter referenceTransactionId: String
+    ///
+    /// - Parameter referenceOrderId: String
+    ///
+    /// - Parameter referenceMerchantTransactionId: String
+    ///
+    /// - Parameter referenceMerchantOrderId: String
+    ///
+    /// - Returns:FiservTTPChargeResponse
+    ///
+    /// - Throws: An error of type FiservTTPCardReaderError
+    ///
     public func voidTransaction(amount: Decimal,
                                 referenceTransactionId: String? = nil,
                                 referenceOrderId: String? = nil,
@@ -265,7 +397,7 @@ public class FiservTTPCardReader {
                                              referenceMerchantOrderId: referenceMerchantOrderId,
                                              referenceTransactionType: "CHARGES",
                                              total: amount,
-                                             currencyCode: "USD")
+                                             currencyCode: self.configuration.currencyCode)
         
         switch voidResult {
             
@@ -281,6 +413,24 @@ public class FiservTTPCardReader {
         }
     }
     
+    /// Refund a transaction
+    ///
+    /// This method provides a way to refund an existing transaction. At least one of the optional values must be provided.
+    ///
+    /// - Parameter amount: Decimal
+    ///
+    /// - Parameter referenceTransactionId: String
+    ///
+    /// - Parameter referenceOrderId: String
+    ///
+    /// - Parameter referenceMerchantTransactionId: String
+    ///
+    /// - Parameter referenceMerchantOrderId: String
+    ///
+    /// - Returns:FiservTTPChargeResponse
+    ///
+    /// - Throws: An error of type FiservTTPCardReaderError
+    ///
     public func refundTransaction(amount: Decimal,
                                   referenceTransactionId: String? = nil,
                                   referenceOrderId: String? = nil,
@@ -295,7 +445,7 @@ public class FiservTTPCardReader {
                                                  referenceMerchantOrderId: referenceMerchantOrderId,
                                                  referenceTransactionType: "CHARGES",
                                                  total: amount,
-                                                 currencyCode: "USD")
+                                                 currencyCode: self.configuration.currencyCode)
         
         switch refundResult {
             
@@ -308,6 +458,86 @@ public class FiservTTPCardReader {
             throw FiservTTPCardReaderError(title: title,
                                            localizedDescription: err.localizedDescription,
                                            failureReason: err.failureReason)
+        }
+    }
+    
+    /// Read and process a card for the amount provided
+    ///
+    /// This method allows a card to be refunded for the specified amount.
+    ///
+    /// - Parameter amount: Decimal
+    ///
+    /// - Parameter referenceTransactionId: String
+    ///
+    /// - Parameter referenceOrderId: String
+    ///
+    /// - Parameter referenceMerchantTransactionId: String
+    ///
+    /// - Parameter referenceMerchantOrderId: String
+    ///
+    /// - Returns:FiservTTPChargeResponse
+    ///
+    /// - Throws: An error of type FiservTTPCardReaderError
+    ///
+    public func refundCard(amount: Decimal,
+                           referenceTransactionId: String? = nil,
+                           referenceOrderId: String? = nil,
+                           referenceMerchantTransactionId: String? = nil,
+                           referenceMerchantOrderId: String? = nil) async throws -> FiservTTPChargeResponse {
+        
+        let title = "Refund Payment Card"
+        
+        guard let readerIdentifier = self.fiservTTPReader.readerIdentifier() else {
+            
+            throw FiservTTPCardReaderError(title: title,
+                                           localizedDescription: NSLocalizedString("Payment Card Reader not identified.", comment: ""))
+        }
+        
+        let result = try await self.fiservTTPReader.readCard(for: amount,
+                                                             currencyCode: self.configuration.currencyCode,
+                                                             transactionType: .refund,
+                                                             eventHandler: { _ in
+        })
+        
+        switch result {
+            
+        case .success(let cardReadResult):
+            
+            guard let generalCardData = cardReadResult.generalCardData, let _ = cardReadResult.paymentCardData else {
+                
+                throw FiservTTPCardReaderError(title: title,
+                                               localizedDescription: NSLocalizedString("Payment Card data missing or corrupt.", comment: ""))
+            }
+            
+            let refundCardResult = await services.refundCard(referenceTransactionId: referenceTransactionId,
+                                                             referenceOrderId: referenceOrderId,
+                                                             referenceMerchantTransactionId: referenceMerchantTransactionId,
+                                                             referenceMerchantOrderId: referenceMerchantOrderId,
+                                                             referenceTransactionType: "CHARGES",
+                                                             total: amount,
+                                                             currencyCode: self.configuration.currencyCode,
+                                                             paymentCardReaderId: readerIdentifier,
+                                                             paymentCardReadResult: cardReadResult)
+            
+            switch refundCardResult {
+                
+            case .success(let response):
+                
+                let appendedResponse = appGeneralCardData(generalCardData: generalCardData, response: response)
+                
+                return appendedResponse
+            
+            case .failure(let err):
+                
+                throw FiservTTPCardReaderError(title: title,
+                                               localizedDescription: err.localizedDescription,
+                                               failureReason: err.failureReason)
+            }
+            
+        case .failure(let error):
+            
+            throw FiservTTPCardReaderError(title: title,
+                                           localizedDescription: error.localizedDescription)
         }
     }
     
@@ -335,5 +565,39 @@ public class FiservTTPCardReader {
         }
         
         return data.map { String(format: "%02hhx", $0) }.joined()
+    }
+}
+
+extension FiservTTPCardReader {
+    
+    func decode(jwtToken jwt: String) throws -> [String: Any] {
+
+        enum DecodeErrors: Error {
+            case badToken
+            case other
+        }
+
+        func base64Decode(_ base64: String) throws -> Data {
+            let base64 = base64
+                .replacingOccurrences(of: "-", with: "+")
+                .replacingOccurrences(of: "_", with: "/")
+            let padded = base64.padding(toLength: ((base64.count + 3) / 4) * 4, withPad: "=", startingAt: 0)
+            guard let decoded = Data(base64Encoded: padded) else {
+                throw DecodeErrors.badToken
+            }
+            return decoded
+        }
+
+        func decodeJWTPart(_ value: String) throws -> [String: Any] {
+            let bodyData = try base64Decode(value)
+            let json = try JSONSerialization.jsonObject(with: bodyData, options: [])
+            guard let payload = json as? [String: Any] else {
+                throw DecodeErrors.other
+            }
+            return payload
+        }
+
+        let segments = jwt.components(separatedBy: ".")
+        return try decodeJWTPart(segments[1])
     }
 }

--- a/Sources/FiservTTP/FiservTTPCardReader.swift
+++ b/Sources/FiservTTP/FiservTTPCardReader.swift
@@ -185,7 +185,7 @@ public class FiservTTPCardReader {
             // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
             let timestamp = Date().timeIntervalSince1970
             
-            if self.tokenExp - timestamp < (300 - 180) { // 1800 { // 30 minutes
+            if self.tokenExp - timestamp < 1800 { // 30 minutes
                 
                 try await requestSessionToken()   // Auto Refresh
             }
@@ -307,7 +307,7 @@ public class FiservTTPCardReader {
         }
     }
     
-    /// Verify a transaction
+    /// Inquire a transaction
     ///
     /// This method provides a way to lookup an existing transaction. At least one of the optional values must be provided.
     ///
@@ -319,14 +319,6 @@ public class FiservTTPCardReader {
     ///
     /// - Parameter referenceOrderId: String
     ///
-    /// - Parameter referenceClientRequestId: String
-    ///
-    /// - Parameter tokenType: String
-    ///
-    /// - Parameter storeId: String
-    ///
-    /// - Parameter siteId: String
-    ///
     /// - Returns:FiservTTPChargeResponse
     ///
     /// - Throws: An error of type FiservTTPCardReaderError
@@ -334,22 +326,14 @@ public class FiservTTPCardReader {
     public func inquiryTransaction(referenceTransactionId: String? = nil,
                                    referenceMerchantTransactionId: String? = nil,
                                    referenceMerchantOrderId: String? = nil,
-                                   referenceOrderId: String? = nil,
-                                   referenceClientRequestId: String? = nil,
-                                   tokenType: String? = nil,
-                                   storeId: String? = nil,
-                                   siteId: String? = nil) async throws -> [FiservTTPChargeResponse] {
+                                   referenceOrderId: String? = nil) async throws -> [FiservTTPChargeResponse] {
         
         let title = "Inquiry Transaction"
         
         let inquiryResult = await services.inquiry(referenceTransactionId: referenceTransactionId,
                                                    referenceMerchantTransactionId: referenceMerchantTransactionId,
                                                    referenceMerchantOrderId: referenceMerchantOrderId,
-                                                   referenceOrderId: referenceOrderId,
-                                                   referenceClientRequestId: referenceClientRequestId,
-                                                   tokenType: tokenType,
-                                                   storeId: storeId,
-                                                   siteId: siteId)
+                                                   referenceOrderId: referenceOrderId)
         
         switch inquiryResult {
             
@@ -373,11 +357,7 @@ public class FiservTTPCardReader {
     ///
     /// - Parameter referenceTransactionId: String
     ///
-    /// - Parameter referenceOrderId: String
-    ///
     /// - Parameter referenceMerchantTransactionId: String
-    ///
-    /// - Parameter referenceMerchantOrderId: String
     ///
     /// - Returns:FiservTTPChargeResponse
     ///
@@ -385,16 +365,12 @@ public class FiservTTPCardReader {
     ///
     public func voidTransaction(amount: Decimal,
                                 referenceTransactionId: String? = nil,
-                                referenceOrderId: String? = nil,
-                                referenceMerchantTransactionId: String? = nil,
-                                referenceMerchantOrderId: String? = nil) async throws -> FiservTTPChargeResponse {
+                                referenceMerchantTransactionId: String? = nil) async throws -> FiservTTPChargeResponse {
         
         let title = "Void Transaction"
         
         let voidResult = await services.void(referenceTransactionId: referenceTransactionId,
-                                             referenceOrderId: referenceOrderId,
                                              referenceMerchantTransactionId: referenceMerchantTransactionId,
-                                             referenceMerchantOrderId: referenceMerchantOrderId,
                                              referenceTransactionType: "CHARGES",
                                              total: amount,
                                              currencyCode: self.configuration.currencyCode)
@@ -421,11 +397,7 @@ public class FiservTTPCardReader {
     ///
     /// - Parameter referenceTransactionId: String
     ///
-    /// - Parameter referenceOrderId: String
-    ///
     /// - Parameter referenceMerchantTransactionId: String
-    ///
-    /// - Parameter referenceMerchantOrderId: String
     ///
     /// - Returns:FiservTTPChargeResponse
     ///
@@ -433,16 +405,12 @@ public class FiservTTPCardReader {
     ///
     public func refundTransaction(amount: Decimal,
                                   referenceTransactionId: String? = nil,
-                                  referenceOrderId: String? = nil,
-                                  referenceMerchantTransactionId: String? = nil,
-                                  referenceMerchantOrderId: String? = nil) async throws -> FiservTTPChargeResponse {
+                                  referenceMerchantTransactionId: String? = nil) async throws -> FiservTTPChargeResponse {
         
         let title = "Refund Transaction"
         
         let refundResult = await services.refund(referenceTransactionId: referenceTransactionId,
-                                                 referenceOrderId: referenceOrderId,
                                                  referenceMerchantTransactionId: referenceMerchantTransactionId,
-                                                 referenceMerchantOrderId: referenceMerchantOrderId,
                                                  referenceTransactionType: "CHARGES",
                                                  total: amount,
                                                  currencyCode: self.configuration.currencyCode)
@@ -469,11 +437,7 @@ public class FiservTTPCardReader {
     ///
     /// - Parameter referenceTransactionId: String
     ///
-    /// - Parameter referenceOrderId: String
-    ///
     /// - Parameter referenceMerchantTransactionId: String
-    ///
-    /// - Parameter referenceMerchantOrderId: String
     ///
     /// - Returns:FiservTTPChargeResponse
     ///
@@ -481,9 +445,7 @@ public class FiservTTPCardReader {
     ///
     public func refundCard(amount: Decimal,
                            referenceTransactionId: String? = nil,
-                           referenceOrderId: String? = nil,
-                           referenceMerchantTransactionId: String? = nil,
-                           referenceMerchantOrderId: String? = nil) async throws -> FiservTTPChargeResponse {
+                           referenceMerchantTransactionId: String? = nil) async throws -> FiservTTPChargeResponse {
         
         let title = "Refund Payment Card"
         
@@ -510,9 +472,7 @@ public class FiservTTPCardReader {
             }
             
             let refundCardResult = await services.refundCard(referenceTransactionId: referenceTransactionId,
-                                                             referenceOrderId: referenceOrderId,
                                                              referenceMerchantTransactionId: referenceMerchantTransactionId,
-                                                             referenceMerchantOrderId: referenceMerchantOrderId,
                                                              referenceTransactionType: "CHARGES",
                                                              total: amount,
                                                              currencyCode: self.configuration.currencyCode,
@@ -553,7 +513,8 @@ public class FiservTTPCardReader {
                                                        transactionInteraction: response.transactionInteraction,
                                                        merchantDetails: response.merchantDetails,
                                                        networkDetails: response.networkDetails,
-                                                       cardDetails: response.cardDetails)
+                                                       cardDetails: response.cardDetails,
+                                                       error: response.error)
         
         return appendedResponse
     }

--- a/Sources/FiservTTP/FiservTTPModels.swift
+++ b/Sources/FiservTTP/FiservTTPModels.swift
@@ -43,9 +43,9 @@ public struct FiservTTPErrorWrapper: Identifiable {
 public struct FiservTTPResponseWrapper: Identifiable {
     public let id: UUID
     public let title: String
-    public let response: FiservTTPChargeResponse
+    public let response: FiservTTPChargeResponse?
     
-    public init(id: UUID = UUID(), title: String, response: FiservTTPChargeResponse) {
+    public init(id: UUID = UUID(), title: String, response: FiservTTPChargeResponse?) {
         self.id = id
         self.title = title
         self.response = response
@@ -142,6 +142,58 @@ public struct FiservTTPValidateCardResponse: Codable {
     let id: String
     public let generalCardData: String?
     public let paymentCardData: String?
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// INQUIRY REQUEST MODEL
+
+internal struct FiservTTPInquiryReferenceTransactionDetails: Codable {
+    
+    let referenceTransactionId: String?
+    let referenceMerchantTransactionId: String?
+    let referenceMerchantOrderId: String?
+    let referenceOrderId: String?
+    let referenceClientRequestId: String?
+    
+    internal init(referenceTransactionId: String? = nil,
+                  referenceMerchantTransactionId: String? = nil,
+                  referenceMerchantOrderId: String? = nil,
+                  referenceOrderId: String? = nil,
+                  referenceClientRequestId: String? = nil) {
+        
+        self.referenceTransactionId = referenceTransactionId
+        self.referenceMerchantTransactionId = referenceMerchantTransactionId
+        self.referenceMerchantOrderId = referenceMerchantOrderId
+        self.referenceOrderId = referenceOrderId
+        self.referenceClientRequestId = referenceClientRequestId
+    }
+}
+
+internal struct FiservTTPInquiryMerchantDetails: Codable {
+    
+    let tokenType: String?
+    let storeId: String?
+    let siteId: String?
+    let terminalId: String?
+    let merchantId: String?
+    
+    internal init(tokenType: String? = nil,
+                  storeId: String? = nil,
+                  siteId: String? = nil,
+                  terminalId: String? = nil,
+                  merchantId: String? = nil) {
+        
+        self.tokenType = tokenType
+        self.storeId = storeId
+        self.siteId = siteId
+        self.terminalId = terminalId
+        self.merchantId = merchantId
+    }
+}
+
+internal struct FiservTTPInquiryRequest: Codable {
+    let referenceTransactionDetails: FiservTTPInquiryReferenceTransactionDetails
+    let merchantDetails: FiservTTPInquiryMerchantDetails
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -284,6 +336,70 @@ internal struct FiservTTPRefundRequest: Codable {
     let referenceTransactionDetails: FiservTTPRefundReferenceTransactionDetails
     let amount: FiservTTPRefundRequestAmount
     let merchantDetails: FiservTTPRefundMerchantDetails
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// REFUND CARD REQUEST AND RESPONSE MODEL
+
+internal struct FiservTTPRefundCardRequestAmount: Codable {
+    let total: Decimal
+    let currency: String
+}
+
+internal struct FiservTTPRefundCardRequestMerchantDetails: Codable {
+    let merchantId: String
+    let terminalId: String
+}
+
+internal struct FiservTTPRefundCardRequestSource: Codable {
+    let sourceType: String
+    let generalCardData: String
+    let paymentCardData: String
+    let cardReaderId: String
+    let cardReaderTransactionId: String
+    let appleTtpMerchantId: String?
+}
+
+internal struct FiservTTPRefundCardRequestPosFeatures: Codable {
+    let pinAuthenticationCapability: String
+    let terminalEntryCapability: String
+}
+
+
+internal struct FiservTTPRefundCardRequestAdditionalDataCommon: Codable {
+    let origin: FiservTTPRefundCardRequestAdditionalDataCommonProcessors
+}
+
+internal struct FiservTTPRefundCardRequestAdditionalDataCommonProcessors: Codable {
+    let processors: FiservTTPRefundCardRequestAdditionalDataCommonProcessor
+}
+
+internal struct FiservTTPRefundCardRequestAdditionalDataCommonProcessor: Codable {
+    let processorName: String
+    let processingPlatform: String
+    let settlementPlatform: String
+    let priority: String
+}
+
+internal struct FiservTTPRefundCardRequestDataEntrySource: Codable {
+    let dataEntrySource: String
+    let posFeatures: FiservTTPRefundCardRequestPosFeatures
+}
+
+internal struct FiservTTPRefundCardRequestTransactionInteraction: Codable {
+    let origin: String
+    let posEntryMode: String
+    let posConditionCode: String
+    let additionalPosInformation: FiservTTPRefundCardRequestDataEntrySource
+}
+
+internal struct FiservTTPRefundCardRequest: Codable {
+    let amount: FiservTTPRefundCardRequestAmount
+    let source: FiservTTPRefundCardRequestSource
+    let referenceTransactionDetails: FiservTTPRefundReferenceTransactionDetails?
+    let transactionInteraction: FiservTTPRefundCardRequestTransactionInteraction
+    let merchantDetails: FiservTTPRefundCardRequestMerchantDetails
+    let additionalDataCommon: FiservTTPRefundCardRequestAdditionalDataCommon
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/Sources/FiservTTP/FiservTTPModels.swift
+++ b/Sources/FiservTTP/FiservTTPModels.swift
@@ -44,11 +44,13 @@ public struct FiservTTPResponseWrapper: Identifiable {
     public let id: UUID
     public let title: String
     public let response: FiservTTPChargeResponse?
+    public let responses: [FiservTTPChargeResponse]?
     
-    public init(id: UUID = UUID(), title: String, response: FiservTTPChargeResponse?) {
+    public init(id: UUID = UUID(), title: String, response: FiservTTPChargeResponse? = nil, responses: [FiservTTPChargeResponse]? = nil) {
         self.id = id
         self.title = title
         self.response = response
+        self.responses = responses
     }
 }
 
@@ -275,20 +277,14 @@ internal struct FiservTTPVoidMerchantDetails: Codable {
 
 internal struct FiservTTPVoidReferenceTransactionDetails: Codable {
     let referenceTransactionId: String?
-    let referenceOrderId: String?
     let referenceMerchantTransactionId: String?
-    let referenceMerchantOrderId: String?
     let referenceTransactionType: String
     
     internal init(referenceTransactionId: String? = nil,
-                  referenceOrderId: String? = nil,
                   referenceMerchantTransactionId: String? = nil,
-                  referenceMerchantOrderId: String? = nil,
                   referenceTransactionType: String) {
         self.referenceTransactionId = referenceTransactionId
-        self.referenceOrderId = referenceOrderId
         self.referenceMerchantTransactionId = referenceMerchantTransactionId
-        self.referenceMerchantOrderId = referenceMerchantOrderId
         self.referenceTransactionType = referenceTransactionType
     }
 }
@@ -314,20 +310,14 @@ internal struct FiservTTPRefundMerchantDetails: Codable {
 
 internal struct FiservTTPRefundReferenceTransactionDetails: Codable {
     let referenceTransactionId: String?
-    let referenceOrderId: String?
     let referenceMerchantTransactionId: String?
-    let referenceMerchantOrderId: String?
     let referenceTransactionType: String
     
     internal init(referenceTransactionId: String? = nil,
-                  referenceOrderId: String? = nil,
                   referenceMerchantTransactionId: String? = nil,
-                  referenceMerchantOrderId: String? = nil,
                   referenceTransactionType: String) {
         self.referenceTransactionId = referenceTransactionId
-        self.referenceOrderId = referenceOrderId
         self.referenceMerchantTransactionId = referenceMerchantTransactionId
-        self.referenceMerchantOrderId = referenceMerchantOrderId
         self.referenceTransactionType = referenceTransactionType
     }
 }
@@ -439,6 +429,7 @@ public struct FiservTTPChargeResponse: Codable {
     public let merchantDetails: FiservTTPChargeResponseMerchantDetails?
     public let networkDetails: FiservTTPChargeResponseNetworkDetails?
     public let cardDetails: FiservTTPChargeResponseCardDetails?
+    public let error: [FiservTTPServerErrorError]?
 }
 
 public struct FiservTTPChargeResponseGatewayResponse: Codable {

--- a/Sources/FiservTTP/FiservTTPServices.swift
+++ b/Sources/FiservTTP/FiservTTPServices.swift
@@ -208,32 +208,22 @@ protocol FiservTTPServicesProtocol {
     func inquiry(referenceTransactionId: String?,
                  referenceMerchantTransactionId: String?,
                  referenceMerchantOrderId: String?,
-                 referenceOrderId: String?,
-                 referenceClientRequestId: String?,
-                 tokenType: String?,
-                 storeId: String?,
-                 siteId: String?) async -> Result<[FiservTTPChargeResponse], FiservTTPRequestError>
+                 referenceOrderId: String?) async -> Result<[FiservTTPChargeResponse], FiservTTPRequestError>
     
     func void(referenceTransactionId: String?,
-              referenceOrderId: String?,
               referenceMerchantTransactionId: String?,
-              referenceMerchantOrderId: String?,
               referenceTransactionType: String,
               total: Decimal,
               currencyCode: String) async -> Result<FiservTTPChargeResponse, FiservTTPRequestError>
     
     func refund(referenceTransactionId: String?,
-                referenceOrderId: String?,
                 referenceMerchantTransactionId: String?,
-                referenceMerchantOrderId: String?,
                 referenceTransactionType: String,
                 total: Decimal,
                 currencyCode: String) async -> Result<FiservTTPChargeResponse, FiservTTPRequestError>
     
     func refundCard(referenceTransactionId: String?,
-                    referenceOrderId: String?,
                     referenceMerchantTransactionId: String?,
-                    referenceMerchantOrderId: String?,
                     referenceTransactionType: String,
                     total: Decimal,
                     currencyCode: String,
@@ -315,47 +305,33 @@ internal struct FiservTTPServices: FiservTTPServicesProtocol {
     internal func inquiry(referenceTransactionId: String? = nil,
                           referenceMerchantTransactionId: String? = nil,
                           referenceMerchantOrderId: String? = nil,
-                          referenceOrderId: String? = nil,
-                          referenceClientRequestId: String? = nil,
-                          tokenType: String? = nil,
-                          storeId: String? = nil,
-                          siteId: String? = nil) async -> Result<[FiservTTPChargeResponse], FiservTTPRequestError> {
+                          referenceOrderId: String? = nil) async -> Result<[FiservTTPChargeResponse], FiservTTPRequestError> {
         
         return await sendRequest(endpoint: inquiryEndpoint,
                                  httpBody: bodyForInquiryRequest(referenceTransactionId: referenceTransactionId,
                                                                  referenceMerchantTransactionId: referenceMerchantTransactionId,
                                                                  referenceMerchantOrderId: referenceMerchantOrderId,
-                                                                 referenceOrderId: referenceOrderId,
-                                                                 referenceClientRequestId: referenceClientRequestId,
-                                                                 tokenType: tokenType,
-                                                                 storeId: storeId,
-                                                                 siteId: siteId),
+                                                                 referenceOrderId: referenceOrderId),
                                                                  responseModel: [FiservTTPChargeResponse].self)
     }
     
     internal func void(referenceTransactionId: String? = nil,
-                       referenceOrderId: String? = nil,
                        referenceMerchantTransactionId: String? = nil,
-                       referenceMerchantOrderId: String? = nil,
                        referenceTransactionType: String,
                        total: Decimal,
                        currencyCode: String) async -> Result<FiservTTPChargeResponse, FiservTTPRequestError> {
         
         return await sendRequest(endpoint: voidEndpoint,
                                  httpBody: bodyForVoidRequest(referenceTransactionId: referenceTransactionId,
-                                                                referenceOrderId: referenceOrderId,
-                                                                referenceMerchantTransactionId: referenceMerchantTransactionId,
-                                                                referenceMerchantOrderId: referenceMerchantOrderId,
-                                                                referenceTransactionType: referenceTransactionType,
-                                                                total: total,
-                                                                currencyCode: currencyCode),
-                                                                responseModel: FiservTTPChargeResponse.self)
+                                                              referenceMerchantTransactionId: referenceMerchantTransactionId,
+                                                              referenceTransactionType: referenceTransactionType,
+                                                              total: total,
+                                                              currencyCode: currencyCode),
+                                                              responseModel: FiservTTPChargeResponse.self)
     }
     
     internal func refund(referenceTransactionId: String? = nil,
-                         referenceOrderId: String? = nil,
                          referenceMerchantTransactionId: String? = nil,
-                         referenceMerchantOrderId: String? = nil,
                          referenceTransactionType: String,
                          total: Decimal,
                          currencyCode: String) async -> Result<FiservTTPChargeResponse, FiservTTPRequestError> {
@@ -363,9 +339,7 @@ internal struct FiservTTPServices: FiservTTPServicesProtocol {
         
         return await sendRequest(endpoint: refundEndpoint,
                                  httpBody: bodyForRefundRequest(referenceTransactionId: referenceTransactionId,
-                                                                referenceOrderId: referenceOrderId,
                                                                 referenceMerchantTransactionId: referenceMerchantTransactionId,
-                                                                referenceMerchantOrderId: referenceMerchantOrderId,
                                                                 referenceTransactionType: referenceTransactionType,
                                                                 total: total,
                                                                 currencyCode: currencyCode),
@@ -373,9 +347,7 @@ internal struct FiservTTPServices: FiservTTPServicesProtocol {
     }
     
     internal func refundCard(referenceTransactionId: String? = nil,
-                             referenceOrderId: String? = nil,
                              referenceMerchantTransactionId: String? = nil,
-                             referenceMerchantOrderId: String? = nil,
                              referenceTransactionType: String,
                              total: Decimal,
                              currencyCode: String,
@@ -390,9 +362,7 @@ internal struct FiservTTPServices: FiservTTPServicesProtocol {
         
         return await sendRequest(endpoint: refundEndpoint,
                                  httpBody: bodyForRefundCardRequest(referenceTransactionId: referenceTransactionId,
-                                                                    referenceOrderId: referenceOrderId,
                                                                     referenceMerchantTransactionId: referenceMerchantTransactionId,
-                                                                    referenceMerchantOrderId: referenceMerchantOrderId,
                                                                     referenceTransactionType: referenceTransactionType,
                                                                     total: total,
                                                                     currencyCode: currencyCode,
@@ -413,7 +383,7 @@ internal struct FiservTTPServices: FiservTTPServicesProtocol {
         
         let tokenRequest = FiservTTPTokenRequest(terminalProfileId: self.config.terminalProfileId,
                                                  channel: "ISV",
-                                                 accessTokenTimeToLive: 300, // 172000,
+                                                 accessTokenTimeToLive: 172000,
                                                  dynamicDescriptors: dynamicDescriptors,
                                                  merchantDetails: merchantDetails,
                                                  appleTtpMerchantId: self.config.appleTtpMerchantId)
@@ -486,21 +456,17 @@ internal struct FiservTTPServices: FiservTTPServicesProtocol {
     internal func bodyForInquiryRequest(referenceTransactionId: String? = nil,
                                             referenceMerchantTransactionId: String? = nil,
                                             referenceMerchantOrderId: String? = nil,
-                                            referenceOrderId: String? = nil,
-                                            referenceClientRequestId: String? = nil,
-                                            tokenType: String? = nil,
-                                            storeId: String? = nil,
-                                            siteId: String? = nil) -> Data? {
+                                            referenceOrderId: String? = nil) -> Data? {
             
             let referenceTransactionDetails = FiservTTPInquiryReferenceTransactionDetails(referenceTransactionId: referenceTransactionId,
                                                                                          referenceMerchantTransactionId: referenceMerchantTransactionId,
                                                                                          referenceMerchantOrderId: referenceMerchantOrderId,
                                                                                          referenceOrderId: referenceOrderId,
-                                                                                         referenceClientRequestId: referenceClientRequestId)
+                                                                                         referenceClientRequestId: nil)
             
-            let merchantDetails = FiservTTPInquiryMerchantDetails(tokenType: tokenType,
-                                                                  storeId: storeId,
-                                                                  siteId: siteId,
+            let merchantDetails = FiservTTPInquiryMerchantDetails(tokenType: nil,
+                                                                  storeId: nil,
+                                                                  siteId: nil,
                                                                   terminalId: self.config.terminalId,
                                                                   merchantId: self.config.merchantId)
             
@@ -514,9 +480,7 @@ internal struct FiservTTPServices: FiservTTPServicesProtocol {
         }
     
     internal func bodyForVoidRequest(referenceTransactionId: String? = nil,
-                                     referenceOrderId: String? = nil,
                                      referenceMerchantTransactionId: String? = nil,
-                                     referenceMerchantOrderId: String? = nil,
                                      referenceTransactionType: String,
                                      total: Decimal,
                                      currencyCode: String) -> Data? {
@@ -526,9 +490,7 @@ internal struct FiservTTPServices: FiservTTPServicesProtocol {
         let voidMerchantDetails = FiservTTPVoidMerchantDetails(terminalId: self.config.terminalId, merchantId: self.config.merchantId)
         
         let referenceTransactionDetails = FiservTTPVoidReferenceTransactionDetails(referenceTransactionId: referenceTransactionId,
-                                                                                   referenceOrderId: referenceOrderId,
                                                                                    referenceMerchantTransactionId: referenceMerchantTransactionId,
-                                                                                   referenceMerchantOrderId: referenceMerchantOrderId,
                                                                                    referenceTransactionType: referenceTransactionType)
         
         let voidRequest = FiservTTPVoidRequest(referenceTransactionDetails: referenceTransactionDetails,
@@ -543,21 +505,17 @@ internal struct FiservTTPServices: FiservTTPServicesProtocol {
     }
     
     internal func bodyForRefundRequest(referenceTransactionId: String? = nil,
-                                      referenceOrderId: String? = nil,
-                                      referenceMerchantTransactionId: String? = nil,
-                                      referenceMerchantOrderId: String? = nil,
-                                      referenceTransactionType: String,
-                                      total: Decimal,
-                                      currencyCode: String) -> Data? {
+                                       referenceMerchantTransactionId: String? = nil,
+                                       referenceTransactionType: String,
+                                       total: Decimal,
+                                       currencyCode: String) -> Data? {
         
         let refundRequestAmount = FiservTTPRefundRequestAmount(total: total, currency: currencyCode)
         
         let refundMerchantDetails = FiservTTPRefundMerchantDetails(terminalId: self.config.terminalId, merchantId: self.config.merchantId)
         
         let referenceTransactionDetails = FiservTTPRefundReferenceTransactionDetails(referenceTransactionId: referenceTransactionId,
-                                                                                     referenceOrderId: referenceOrderId,
                                                                                      referenceMerchantTransactionId: referenceMerchantTransactionId,
-                                                                                     referenceMerchantOrderId: referenceMerchantOrderId,
                                                                                      referenceTransactionType: referenceTransactionType)
         
         let refundRequest = FiservTTPRefundRequest(referenceTransactionDetails: referenceTransactionDetails,
@@ -572,9 +530,7 @@ internal struct FiservTTPServices: FiservTTPServicesProtocol {
     }
 
     internal func bodyForRefundCardRequest(referenceTransactionId: String? = nil,
-                                           referenceOrderId: String? = nil,
                                            referenceMerchantTransactionId: String? = nil,
-                                           referenceMerchantOrderId: String? = nil,
                                            referenceTransactionType: String,
                                            total: Decimal,
                                            currencyCode: String,
@@ -617,10 +573,9 @@ internal struct FiservTTPServices: FiservTTPServicesProtocol {
         var refundCardRequest: FiservTTPRefundCardRequest
         
         let referenceTransactionDetails = FiservTTPRefundReferenceTransactionDetails(referenceTransactionId: referenceTransactionId,
-                                                                                     referenceOrderId: referenceOrderId,
                                                                                      referenceMerchantTransactionId: referenceMerchantTransactionId,
-                                                                                     referenceMerchantOrderId: referenceMerchantOrderId,
                                                                                      referenceTransactionType: referenceTransactionType)
+
         refundCardRequest = FiservTTPRefundCardRequest(amount: refundRequestAmount,
                                                        source: source,
                                                        referenceTransactionDetails: referenceTransactionDetails,
@@ -676,7 +631,7 @@ internal struct FiservTTPServices: FiservTTPServicesProtocol {
         let timestamp = timestamp
         
         let clientRequestId = clientRequestId
-        print("Request: \(bodyString)")
+        
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         
         request.allHTTPHeaderFields = endpoint.httpHeaders(requestBody: bodyString,
@@ -688,8 +643,7 @@ internal struct FiservTTPServices: FiservTTPServicesProtocol {
         do {
             
             let (data, response) = try await URLSession.shared.data(for: request)
-            let responseString = String(data: data, encoding: .utf8)
-            print("Response: \(responseString ?? "??")")
+
             guard let response = response as? HTTPURLResponse else {
                 return .failure(FiservTTPRequestError(message: "No Response"))
             }


### PR DESCRIPTION
1) Added function to check if Apple TTP Account is already linked - requires iOS 16.4
2) Improved token/session management - see readme file
3) Added support for Open Refunds
4) Added support for Unmatched Tagged  Refunds
5) Added support for Transaction Inquiry