### PR TITLE
COM-21492

### DIFF
--- a/FiservTTP.podspec
+++ b/FiservTTP.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name = 'FiservTTP'
-  s.version = '1.0.6'
+  s.version = '1.0.7'
   s.license = { :type => 'MIT', :file => 'LICENSE' }
   s.summary = 'Tap To Pay on iPhone by Fiserv'
   s.homepage = 'https://github.com/Fiserv/TTPPackage'

--- a/README.md
+++ b/README.md
@@ -149,7 +149,155 @@ do {
 
 **NOTE:** that you must re-initialize the reader session each time the app starts.
 
-### Take a Payment (Charges)
+**- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
+
+### 😀 Account Verification API
+
+**INTERNAL NOTE ONLY**
+
+**CommerceHub supports paymentToken for Account Verification**
+
+**Need to know if we should support it here**
+
+```SWift
+public func accountVerification(transactionDetailsRequest: Models.TransactionDetailsRequest,
+                                paymentTokenSourceRequest: Models.PaymentTokenSourceRequest? = nil,
+                                billingAddressRequest: Models.BillingAddressRequest? = nil) async throws -> Models.AccountVerificationResponse
+```
+
+Additional information can be found here:
+[Commerce Hub Account Verification](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments_VAS/Verification.md&branch=main)
+
+
+**- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
+
+### 😀 Tokenization API
+
+```Swift
+public func tokenizeCard(transactionDetailsRequest: Models.TransactionDetailsRequest) async throws -> Models.TokenizeCardResponse
+```
+
+**NOTE:** the createToken field in the TransactionDetailsRequest does not need to be explicitly set to true.
+
+Additional information can be found here:
+[Commerce Hub Tokenization](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/Guides/Payment-Sources/Tokenization/TransAmor.md&branch=main)
+
+**- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
+### 😀 Charges API
+
+**This API supports Authorizations, Payment Tokens, Capture, and Sale**
+
+```Swift
+public enum PaymentTransactionType {
+    case sale
+    case auth
+    case capture
+    case paymentToken
+}
+```
+
+```Swift
+public func charges(amount: Decimal,
+                    transactionType: PaymentTransactionType,
+                    transactionDetailsRequest: Models.TransactionDetailsRequest,
+                    referenceTransactionDetailsRequest: Models.ReferenceTransactionDetailsRequest? = nil,
+                    paymentTokenSourceRequest: Models.PaymentTokenSourceRequest? = nil) async throws -> Models.CommerceHubResponse
+```
+
+| TRANSACTION TYPE             |    SALE    |    AUTH    |  CAPTURE  |   TOKEN   |
+|------------------------------|------------|------------|-----------|-----------|
+| READ CARD                    |      Y     |      Y     |     N     |     N     |
+| CAPTURE FLAG                 |      T     |      F     |     T     |     T     |
+| TRANSACTION DETAILS          |      Y     |      Y     |     Y     |     Y     |
+| REF TRANS DETAILS            |      N     |      N     |     O     |     N     |
+
+**OPTIONAL -> Reference Transaction Details + Capture must be from a previous Authorization**
+
+**TransactionDetailsRequest.createToken can be true for any PaymentTransactionType -requires Merchant configuration**
+
+Additional Information can be found here:
+[Commerce Hub Charges](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Charges.md&branch=main)
+
+**- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
+
+### 😀 Cancels API
+
+```Swift
+public func cancels(amount: Decimal,
+                    referenceTransactionDetailsRequest: Models.ReferenceTransactionDetailsRequest) async throws -> Models.CommerceHubResponse
+```
+
+**NOTE:** At least one of the values for the referenceTransactionDetailsRequest must be provided.
+
+Additional information can be found here:
+[Commerce Hub Cancel](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Cancel.md&branch=main)
+
+**- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
+### 😀 Refunds API
+
+**This API supports Matched, Unmatched, and Open Refunds**
+
+```Swift
+public enum RefundTransactionType {
+    case matched
+    case unmatched
+    case open
+}
+```
+
+```Swift
+public func refunds(amount: Decimal,
+                    refundTransactionType: RefundTransactionType,
+                    transactionDetails: Models.TransactionDetailsRequest? = nil,
+                    referenceTransactionDetails: Models.ReferenceTransactionDetailsRequest? = nil) async throws -> Models.CommerceHubResponse
+```
+
+| TRANSACTION TYPE             |    MATCHED    |   UNMATCHED   |    OPEN    |
+|------------------------------|---------------|---------------|------------|
+| READ CARD                    |      N        |      Y        |     Y      |
+| CAPTURE FLAG                 |      F        |      T        |     T      |
+| TRANSACTION DETAILS          |      N        |      Y        |     Y      |
+| REF TRANS DETAILS            |      Y        |      Y        |     N      |
+
+Additional information can be found here:
+[Commerce Hub Matched Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Tagged.md&branch=main)
+
+Additional information can be found here:
+[Commerce Hub Unmatched Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Unmatched.md&branch=main)
+
+Additional information can be found here:
+[Commerce Hub Open Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Open.md&branch=main)
+
+**- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
+### 😀 Transaction Inquiry API
+
+To retrieve the current state of any previous transaction, an inquiry request can be submitted against the Commerce Hub transaction identifier or merchant transaction identifier.
+
+**NOTE:** At least one of the values for the referenceTransactionDetailsRequest must be provided.
+
+```Swift
+public func transactionInquiry(referenceTransactionDetailsRequest: Models.ReferenceTransactionDetailsRequest) async throws -> [Models.InquireResponse]
+```
+
+Additional information can be found here:
+[Commerce Hub Inquiry](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Inquiry.md&branch=main)
+
+**- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
+
+## Download the sample app
+We've prepared an end-to-end sample app to get you up and running fast. [Get the Sample App here](https://github.com/Fiserv/TTPSampleApp)
+
+## Additional Resources
+[Commerce Hub](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/Master-Data/Reference-Transaction-Details.md)
+
+[Sample App](https://github.com/Fiserv/TTPSampleApp)  
+
+[Merchant FAQ's from Apple](https://register.apple.com/tap-to-pay-on-iphone/faq) 
+[Tap to Pay on iPhone Security from Apple](https://support.apple.com/guide/security/tap-to-pay-on-iphone-sec72cb155f4/web)
+
+**- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
+
+### ⛔️ DEPRECATED - Take a Payment (Charges)
 Congrats on getting this far!  Now you are ready to process your first payment.  Simply make this call and the SDK takes care of the rest for you:
 
 ```Swift
@@ -172,23 +320,27 @@ do {
 Additional information can be found here:
 [Commerce Hub Charges](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Charges.md&branch=main)
 
-### Cancel a Payment
+### ⛔️ DEPRECATED - Inquiry
+
+To retrieve the current state of any previous transaction, an inquiry request can be submitted against the Commerce Hub transaction identifier or merchant transaction identifier.
+
+**NOTE:** At least one of the arguments must be provided.
 
 ```Swift
-let amount = 10.99 // amount to void
-let referenceTransactionId = "this value was returned in the charge response"
 do {
-  let voidResponse = try await fiservTTPCardReader.voidTransaction(amount: amount,
-                                                                   referenceTransactionId = referenceTransactionId)
-    // TODO inspect the voidResponse to see the result
+    let inquireResponse = try await fiservTTPCardReader.inquiryTransaction(referenceTransactionId: referenceTransactionId,
+                                                                           referenceMerchantTransactionId: referenceMerchantTransactionId,
+                                                                           referenceMerchantOrderId: referenceMerchantOrderId,
+                                                                           referenceOrderId: referenceOrderId)
+    // TODO inspect the Inquire Response to see the result
 } catch let error as FiservTTPCardReaderError {
     // TODO handle exception
 }
 ```
 Additional information can be found here:
-[Commerce Hub Cancel](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Cancel.md&branch=main)
+[Commerce Hub Inquiry](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Inquiry.md&branch=main)
 
-### Refund Payment without Tap
+### ⛔️ DEPRECATED - Refund Payment without Tap
 
 At least one reference transaction identifier must be provided to perform a Tagged Refund.
 
@@ -209,7 +361,7 @@ do {
 Additional information can be found here:
 [Commerce Hub Matched Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Tagged.md&branch=main)
 
-### Refund Payment with Tap (Unmatched Tagged Refund and Open Refund)
+### ⛔️ DEPRECATED - Refund Payment with Tap (Unmatched Tagged Refund and Open Refund)
 
 **NOTE:** The fiservTTPCardReader.refundCard API supports both 'Unmatched Tagged Refunds' and 'Open Refunds'.
 
@@ -259,33 +411,22 @@ do {
 Additional information can be found here:
 [Commerce Hub Unmatched Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Unmatched.md&branch=main)
 
-### Inquiry
+**- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
 
-To retrieve the current state of any previous transaction, an inquiry request can be submitted against the Commerce Hub transaction identifier or merchant transaction identifier.
-
-**NOTE:** At least one of the arguments must be provided.
+### ⛔️ DEPRECATED - Cancel a Payment
 
 ```Swift
+let amount = 10.99 // amount to void
+let referenceTransactionId = "this value was returned in the charge response"
 do {
-    let inquireResponse = try await fiservTTPCardReader.inquiryTransaction(referenceTransactionId: referenceTransactionId,
-                                                                           referenceMerchantTransactionId: referenceMerchantTransactionId,
-                                                                           referenceMerchantOrderId: referenceMerchantOrderId,
-                                                                           referenceOrderId: referenceOrderId)
-    // TODO inspect the Inquire Response to see the result
+  let voidResponse = try await fiservTTPCardReader.voidTransaction(amount: amount,
+                                                                   referenceTransactionId = referenceTransactionId)
+    // TODO inspect the voidResponse to see the result
 } catch let error as FiservTTPCardReaderError {
     // TODO handle exception
 }
 ```
 Additional information can be found here:
-[Commerce Hub Inquiry](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Inquiry.md&branch=main)
+[Commerce Hub Cancel](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Cancel.md&branch=main)
 
-## Download the sample app
-We've prepared an end-to-end sample app to get you up and running fast. [Get the Sample App here](https://github.com/Fiserv/TTPSampleApp)
 
-## Additional Resources
-[Commerce Hub](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/Master-Data/Reference-Transaction-Details.md)
-
-[Sample App](https://github.com/Fiserv/TTPSampleApp)  
-
-[Merchant FAQ's from Apple](https://register.apple.com/tap-to-pay-on-iphone/faq) 
-[Tap to Pay on iPhone Security from Apple](https://support.apple.com/guide/security/tap-to-pay-on-iphone-sec72cb155f4/web)

--- a/README.md
+++ b/README.md
@@ -151,108 +151,6 @@ do {
 
 **- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
 
-#### Account Verification
-
-```SWift
-public func accountVerification(transactionDetailsRequest: Models.TransactionDetailsRequest,
-                                paymentTokenSourceRequest: Models.PaymentTokenSourceRequest? = nil,
-                                billingAddressRequest: Models.BillingAddressRequest? = nil) async throws -> Models.AccountVerificationResponse
-```
-Use the code snippet below to perform an account verification.
-```Swift
-let usesAddress = true
-let amount = 12.04
-let createPaymentToken = true
-let merchantOrderId = "1234567890" // Unique merchant order ID
-let merchantTransactionId = "1234567890" // Unique merchant transaction ID
-let merchantInvoiceNumber = "1234567890" // Optional
-let transactionDetails = Models.TransactionDetailsRequest(
-    merchantTransactionId: merchantTransactionId,
-    merchantOrderId: merchantOrderId,
-    merchantInvoiceNumber: merchantInvoiceNumber,
-    createToken: createPaymentToken
-)
-var addressRequest: Models.AddressRequest?
-var billingAddressRequest: Models.BillingAddressRequest?
-
-if usesAddress {
-    addressRequest = Models.AddressRequest(
-        street: streetName,
-        houseNumberOrName: houseNumber,
-        city: city,
-        stateOrProvince: state,
-        postalCode: postalCode,
-        country: country
-    )
-
-    billingAddressRequest = Models.BillingAddressRequest(
-        firstName: firstName,
-        lastName: lastName,
-        addressRequest: addressRequest
-    )
-}
-
-Task {
-    do {
-        let response = try await self.fiservTTPCardReader.accountVerification(
-            transactionDetailsRequest: transactionDetails,
-            billingAddressRequest: billingAddressRequest
-        )
-
-        if response.gatewayResponse?.transactionState == "VERIFIED" {
-            // Process the response here...
-        }
-    } catch {
-        // Handle Error
-    }
-}
-```
-
-Additional information can be found here:
-[Commerce Hub Account Verification](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments_VAS/Verification.md&branch=main)
-
-
-**- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
-
-#### Tokenization
-
-```Swift
-public func tokenizeCard(transactionDetailsRequest: Models.TransactionDetailsRequest) async throws -> Models.TokenizeCardResponse
-```
-Use the code snippet below to tokenize a card.
-```Swift
-let merchantOrderId = "1234567890" // Unique merchant order ID
-let merchantTransactionId = "1234567890" // Unique merchant transaction ID
-let merchantInvoiceNumber = "1234567890" // Optional
-
-Task {
-    do {
-        let transactionDetailsRequest = Models.TransactionDetailsRequest(
-            merchantTransactionId: merchantTransactionId,
-            merchantOrderId: merchantOrderId,
-            merchantInvoiceNumber: merchantInvoiceNumber
-        )
-
-        let response = try await self.fiservTTPCardReader.tokenizeCard(
-            transactionDetailsRequest: transactionDetailsRequest
-        )
-
-        if response.gatewayResponse?.transactionState == "AUTHORIZED" {
-            // Process the response here...
-        }
-    } catch {
-        // Handle Error
-    }
-}
-```
-
-**NOTE:** the createToken field in the TransactionDetailsRequest does not need to be explicitly set to true.
-
-Additional information can be found here:
-[Commerce Hub Tokenization](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/Guides/Payment-Sources/Tokenization/TransAmor.md&branch=main)
-
-**- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
-
 #### Charges API
 
 **This API supports Authorizations, Payment Tokens, Capture, and Sale**
@@ -432,6 +330,7 @@ Additional information can be found here:
 [Commerce Hub Cancel](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Cancel.md&branch=main)
 
 **- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
+
 #### Refunds API
 
 **This API supports Matched, Unmatched, and Open Refunds**
@@ -558,7 +457,107 @@ Additional information can be found here:
 [Commerce Hub Open Refund](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments/Refund-Open.md&branch=main)
 
 **- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
-### 😀 Transaction Inquiry API
+#### Account Verification
+
+```SWift
+public func accountVerification(transactionDetailsRequest: Models.TransactionDetailsRequest,
+                                paymentTokenSourceRequest: Models.PaymentTokenSourceRequest? = nil,
+                                billingAddressRequest: Models.BillingAddressRequest? = nil) async throws -> Models.AccountVerificationResponse
+```
+Use the code snippet below to perform an account verification.
+```Swift
+let usesAddress = true
+let amount = 12.04
+let createPaymentToken = true
+let merchantOrderId = "1234567890" // Unique merchant order ID
+let merchantTransactionId = "1234567890" // Unique merchant transaction ID
+let merchantInvoiceNumber = "1234567890" // Optional
+let transactionDetails = Models.TransactionDetailsRequest(
+    merchantTransactionId: merchantTransactionId,
+    merchantOrderId: merchantOrderId,
+    merchantInvoiceNumber: merchantInvoiceNumber,
+    createToken: createPaymentToken
+)
+var addressRequest: Models.AddressRequest?
+var billingAddressRequest: Models.BillingAddressRequest?
+
+if usesAddress {
+    addressRequest = Models.AddressRequest(
+        street: streetName,
+        houseNumberOrName: houseNumber,
+        city: city,
+        stateOrProvince: state,
+        postalCode: postalCode,
+        country: country
+    )
+
+    billingAddressRequest = Models.BillingAddressRequest(
+        firstName: firstName,
+        lastName: lastName,
+        addressRequest: addressRequest
+    )
+}
+
+Task {
+    do {
+        let response = try await self.fiservTTPCardReader.accountVerification(
+            transactionDetailsRequest: transactionDetails,
+            billingAddressRequest: billingAddressRequest
+        )
+
+        if response.gatewayResponse?.transactionState == "VERIFIED" {
+            // Process the response here...
+        }
+    } catch {
+        // Handle Error
+    }
+}
+```
+
+Additional information can be found here:
+[Commerce Hub Account Verification](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/API-Documents/Payments_VAS/Verification.md&branch=main)
+
+**- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
+
+#### Tokenization
+
+```Swift
+public func tokenizeCard(transactionDetailsRequest: Models.TransactionDetailsRequest) async throws -> Models.TokenizeCardResponse
+```
+Use the code snippet below to tokenize a card.
+```Swift
+let merchantOrderId = "1234567890" // Unique merchant order ID
+let merchantTransactionId = "1234567890" // Unique merchant transaction ID
+let merchantInvoiceNumber = "1234567890" // Optional
+
+Task {
+    do {
+        let transactionDetailsRequest = Models.TransactionDetailsRequest(
+            merchantTransactionId: merchantTransactionId,
+            merchantOrderId: merchantOrderId,
+            merchantInvoiceNumber: merchantInvoiceNumber
+        )
+
+        let response = try await self.fiservTTPCardReader.tokenizeCard(
+            transactionDetailsRequest: transactionDetailsRequest
+        )
+
+        if response.gatewayResponse?.transactionState == "AUTHORIZED" {
+            // Process the response here...
+        }
+    } catch {
+        // Handle Error
+    }
+}
+```
+
+**NOTE:** the createToken field in the TransactionDetailsRequest does not need to be explicitly set to true.
+
+Additional information can be found here:
+[Commerce Hub Tokenization](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/Guides/Payment-Sources/Tokenization/TransAmor.md&branch=main)
+
+**- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
+#### Transaction Inquiry API
 
 To retrieve the current state of any previous transaction, an inquiry request can be submitted against the Commerce Hub transaction identifier or merchant transaction identifier.
 

--- a/README.md
+++ b/README.md
@@ -277,11 +277,6 @@ Additional Information can be found here:
 
 #### Cancels API
 
-```Swift
-public func cancels(amount: Decimal,
-                    referenceTransactionDetailsRequest: Models.ReferenceTransactionDetailsRequest) async throws -> Models.CommerceHubResponse
-```
-
 Use the code snippet below to perform a cancel (void) transaction using a referenceTransactionId.
 At least one reference transaction identifier must be provided to perform a cancel.
 
@@ -316,21 +311,6 @@ Additional information can be found here:
 #### Refunds API
 
 **This API supports Matched, Unmatched, and Open Refunds**
-
-```Swift
-public enum RefundTransactionType {
-    case matched
-    case unmatched
-    case open
-}
-```
-
-```Swift
-public func refunds(amount: Decimal,
-                    refundTransactionType: RefundTransactionType,
-                    transactionDetails: Models.TransactionDetailsRequest? = nil,
-                    referenceTransactionDetails: Models.ReferenceTransactionDetailsRequest? = nil) async throws -> Models.CommerceHubResponse
-```
 
 | Request Parameters           |    MATCHED    |   UNMATCHED   |    OPEN    |
 |------------------------------|---------------|---------------|------------|
@@ -440,12 +420,8 @@ Additional information can be found here:
 **- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -**
 #### Account Verification
 
-```SWift
-public func accountVerification(transactionDetailsRequest: Models.TransactionDetailsRequest,
-                                paymentTokenSourceRequest: Models.PaymentTokenSourceRequest? = nil,
-                                billingAddressRequest: Models.BillingAddressRequest? = nil) async throws -> Models.AccountVerificationResponse
-```
 Use the code snippet below to perform an account verification.
+
 ```Swift
 let usesAddress = true
 let amount = 12.04
@@ -502,10 +478,8 @@ Additional information can be found here:
 
 #### Tokenization
 
-```Swift
-public func tokenizeCard(transactionDetailsRequest: Models.TransactionDetailsRequest) async throws -> Models.TokenizeCardResponse
-```
 Use the code snippet below to tokenize a card.
+
 ```Swift
 let merchantOrderId = "1234567890" // Unique merchant order ID
 let merchantTransactionId = "1234567890" // Unique merchant transaction ID
@@ -543,10 +517,6 @@ Additional information can be found here:
 To retrieve the current state of any previous transaction, an inquiry request can be submitted against the Commerce Hub transaction identifier or merchant transaction identifier.
 
 **NOTE:** At least one of the values for the referenceTransactionDetailsRequest must be provided.
-
-```Swift
-public func transactionInquiry(referenceTransactionDetailsRequest: Models.ReferenceTransactionDetailsRequest) async throws -> [Models.InquireResponse]
-```
 
 Use the code snippet below to perform a transaction inquiry using a referenceTransactionId.
 At least one reference transaction identifier must be provided to perform an inquiry.

--- a/Sources/FiservTTP/FiservPaymentModels.swift
+++ b/Sources/FiservTTP/FiservPaymentModels.swift
@@ -1,0 +1,781 @@
+//  FiservPaymentModels
+//
+//  Copyright (c) 2022 - 2025 Fiserv, Inc.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+public struct Models {
+    
+    public struct DynamicDescriptorsRequest: Codable {
+        public let merchantCategoryCode: String
+        public let merchantName: String
+        
+        public init(merchantCategoryCode: String, merchantName: String) {
+            self.merchantCategoryCode = merchantCategoryCode
+            self.merchantName = merchantName
+        }
+    }
+    
+    public struct MerchantDetailsRequest: Codable {
+        public let merchantId: String
+        public let terminalId: String
+        
+        public init(merchantId: String, terminalId: String) {
+            self.merchantId = merchantId
+            self.terminalId = terminalId
+        }
+    }
+    
+    public struct SourceRequest: Codable {
+        public let sourceType: String
+        public let generalCardData: String?
+        public let paymentCardData: String?
+        public let cardReaderId: String?
+        public let cardReaderTransactionId: String?
+        public let appleTtpMerchantId: String?
+        
+        public init(sourceType: String,
+                    generalCardData: String?,
+                    paymentCardData: String?,
+                    cardReaderId: String?,
+                    cardReaderTransactionId: String?,
+                    appleTtpMerchantId: String?) {
+            
+            self.sourceType = sourceType
+            self.generalCardData = generalCardData
+            self.paymentCardData = paymentCardData
+            self.cardReaderId = cardReaderId
+            self.cardReaderTransactionId = cardReaderTransactionId
+            self.appleTtpMerchantId = appleTtpMerchantId
+        }
+    }
+    
+    public struct TransactionDetailsRequest: Codable {
+        
+        public let merchantTransactionId: String?
+        public let merchantOrderId: String?
+        public let merchantInvoiceNumber: String?
+        public let captureFlag: Bool
+        public let createToken: Bool
+        
+        public init(merchantTransactionId: String? = nil,
+                    merchantOrderId: String? = nil,
+                    merchantInvoiceNumber: String? = nil,
+                    captureFlag: Bool = false,
+                    createToken: Bool = false) {
+            self.merchantTransactionId = merchantTransactionId
+            self.merchantOrderId = merchantOrderId
+            self.merchantInvoiceNumber = merchantInvoiceNumber
+            self.captureFlag = captureFlag
+            self.createToken = createToken
+        }
+    }
+    
+    public struct ReferenceTransactionDetailsRequest: Codable {
+        
+        public let referenceTransactionId: String?
+        public let referenceMerchantTransactionId: String?
+        public let referenceOrderId: String?
+        public let referenceMerchantOrderId: String?
+        public let referenceClientRequestId: String?
+        
+        public init(referenceTransactionId: String? = nil,
+                    referenceMerchantTransactionId: String? = nil,
+                    referenceOrderId: String? = nil,
+                    referenceMerchantOrderId: String? = nil,
+                    referenceClientRequestId: String? = nil) {
+            
+            self.referenceTransactionId = referenceTransactionId
+            self.referenceMerchantTransactionId = referenceMerchantTransactionId
+            self.referenceOrderId = referenceOrderId
+            self.referenceMerchantOrderId = referenceMerchantOrderId
+            self.referenceClientRequestId = referenceClientRequestId
+        }
+    }
+    
+    // RESPONSE
+    public struct TransactionProcessingDetailsResponse: Codable {
+        public let orderId: String?
+        public let transactionTimestamp: String?
+        public let apiTraceId: String?
+        public let clientRequestId: String?
+        public let transactionId: String?
+        public let apiKey: String?
+    }
+
+    public struct GatewayResponse: Codable {
+        public let transactionType: String?
+        public let transactionState: String?
+        public let transactionOrigin: String?
+        public let transactionProcessingDetails: TransactionProcessingDetailsResponse?
+    }
+    
+    public struct CardResponse: Codable {
+        public let expirationMonth: String?
+        public let expirationYear: String?
+        public let bin: String?
+        public let last4: String?
+        public let scheme: String?
+    }
+    
+    public struct SourceResponse: Codable {
+        public let sourceType: String?
+        public let hasBeenDecrypted: Bool?
+        public let card: CardResponse?
+        public let emvData: String?
+        public let generalCardData: String?
+    }
+    
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // AUTHENTICATION
+    
+    // REQUEST
+    public struct AuthenticateRequest: Codable {
+        public let terminalProfileId: String
+        public let channel: String
+        public let accessTokenTimeToLive: Int
+        public let dynamicDescriptorsRequest: Models.DynamicDescriptorsRequest
+        public let merchantDetailsRequest: Models.MerchantDetailsRequest
+        public let appleTtpMerchantId: String?
+        
+        public init(terminalProfileId: String,
+                    channel: String,
+                    accessTokenTimeToLive: Int,
+                    dynamicDescriptorsRequest: Models.DynamicDescriptorsRequest,
+                    merchantDetailsRequest: MerchantDetailsRequest,
+                    appleTtpMerchantId: String?) {
+
+            self.terminalProfileId = terminalProfileId
+            self.channel = channel
+            self.accessTokenTimeToLive = accessTokenTimeToLive
+            self.dynamicDescriptorsRequest = dynamicDescriptorsRequest
+            self.merchantDetailsRequest = merchantDetailsRequest
+            self.appleTtpMerchantId = appleTtpMerchantId
+        }
+    }
+    
+    // RESPONSE
+    public struct AuthenticateResponse: Codable {
+        public let gatewayResponse: GatewayResponse
+        public let accessToken: String
+        public let accessTokenTimeToLive: Int
+        public let accessTokenType: String
+    }
+    
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // CARD VERIFICATION RESPONSE (APPLE PROXIMITY READER)
+    
+    public struct CardVerificationResponse: Codable {
+        public let cardReaderId: String
+        public let transactionId: String
+        public let generalCardData: String
+        public let paymentCardData: String
+    }
+    
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // ACCOUNT VERIFICATION REQUEST
+    
+    public struct AddressRequest: Codable {
+        public let street: String
+        public let houseNumberOrName: String
+        public let city: String
+        public let stateOrProvince: String
+        public let postalCode: String
+        public let country: String
+        
+        public init(street: String, houseNumberOrName: String, city: String, stateOrProvince: String, postalCode: String, country: String) {
+            self.street = street
+            self.houseNumberOrName = houseNumberOrName
+            self.city = city
+            self.stateOrProvince = stateOrProvince
+            self.postalCode = postalCode
+            self.country = country
+        }
+    }
+        
+    public struct BillingAddressRequest: Codable {
+        public let firstName: String
+        public let lastName: String
+        public let address: AddressRequest?
+        
+        public init(firstName: String, lastName: String, addressRequest: AddressRequest? = nil) {
+            
+            self.firstName = firstName
+            self.lastName = lastName
+            self.address = addressRequest
+        }
+    }
+    
+    public struct PosFeaturesRequest: Codable {
+        public let pinAuthenticationCapability: String
+        public let terminalEntryCapability: String
+        
+        public init(pinAuthenticationCapability: String,
+                    terminalEntryCapability: String) {
+            
+            self.pinAuthenticationCapability = pinAuthenticationCapability
+            self.terminalEntryCapability = terminalEntryCapability
+        }
+    }
+    
+    public struct PosHardwareAndSoftwareRequest: Codable {
+        public let softwareApplicationName: String
+        public let softwareVersionNumber: String
+        public let hardwareVendorIdentifier: String
+        
+        public init(softwareApplicationName: String,
+                    softwareVersionNumber: String,
+                    hardwareVendorIdentifier: String) {
+            
+            self.softwareApplicationName = softwareApplicationName
+            self.softwareVersionNumber = softwareVersionNumber
+            self.hardwareVendorIdentifier = hardwareVendorIdentifier
+        }
+    }
+    
+    public struct DataEntrySourceRequest: Codable {
+        public let dataEntrySource: String
+        public let posFeatures: PosFeaturesRequest
+        public let posHardwareAndSoftware : PosHardwareAndSoftwareRequest?
+        
+        public init(dataEntrySource: String,
+                    posFeatures: PosFeaturesRequest,
+                    posHardwareAndSoftware: PosHardwareAndSoftwareRequest?) {
+            
+            self.dataEntrySource = dataEntrySource
+            self.posFeatures = posFeatures
+            self.posHardwareAndSoftware = posHardwareAndSoftware
+        }
+    }
+    
+    public struct TransactionInteractionRequest: Codable {
+        public let origin: String
+        public let posEntryMode: String
+        public let posConditionCode: String
+        public let additionalPosInformation: Models.DataEntrySourceRequest?
+        
+        public init(origin: String,
+                    posEntryMode: String,
+                    posConditionCode: String,
+                    additionalPosInformation: Models.DataEntrySourceRequest?) {
+            
+            self.origin = origin
+            self.posEntryMode = posEntryMode
+            self.posConditionCode = posConditionCode
+            self.additionalPosInformation = additionalPosInformation
+        }
+    }
+    
+    public struct AccountVerificationRequest: Codable {
+        public let source: SourceRequest
+        public let transactionDetails: TransactionDetailsRequest
+        public let transactionInteraction: TransactionInteractionRequest
+        public let billingAddress: BillingAddressRequest?
+        public let merchantDetails: MerchantDetailsRequest
+        
+        public init(source: SourceRequest,
+                    transactionDetails: TransactionDetailsRequest,
+                    transactionInteraction: TransactionInteractionRequest,
+                    billingAddress: BillingAddressRequest?,
+                    merchantDetails: MerchantDetailsRequest) {
+            self.source = source
+            self.transactionDetails = transactionDetails
+            self.transactionInteraction = transactionInteraction
+            self.billingAddress = billingAddress
+            self.merchantDetails = merchantDetails
+        }
+    }
+    
+    public struct AccountVerificationTokenRequest: Codable {
+        public let source: Models.PaymentTokenSourceRequest
+        public let transactionDetails: TransactionDetailsRequest
+        public let transactionInteraction: TransactionInteractionRequest
+        public let billingAddress: BillingAddressRequest?
+        public let merchantDetails: MerchantDetailsRequest
+        
+        public init(source: Models.PaymentTokenSourceRequest,
+                    transactionDetails: TransactionDetailsRequest,
+                    transactionInteraction: TransactionInteractionRequest,
+                    billingAddress: BillingAddressRequest?,
+                    merchantDetails: MerchantDetailsRequest) {
+            self.source = source
+            self.transactionDetails = transactionDetails
+            self.transactionInteraction = transactionInteraction
+            self.billingAddress = billingAddress
+            self.merchantDetails = merchantDetails
+        }
+    }
+    
+    // ACCOUNT VERIFICATION RESPONSE
+    
+    public struct MerchantDetailsResponse: Codable {
+        public let tokenType: String?
+        public let terminalId: String?
+        public let merchantId: String?
+    }
+    
+    public struct PosFeaturesResponse: Codable {
+        public let pinAuthenticationCapability: String?
+        public let PINcaptureCapability: String?
+        public let terminalEntryCapability: String?
+    }
+    
+    public struct AdditionalPosInformationResponse: Codable {
+        public let dataEntrySource: String?
+        public let stan: String?
+        public let posFeatures: PosFeaturesResponse?
+        public let cardPresentIndicator: String?
+        public let cardPresentAtPosIndicator: String?
+    }
+    
+    public struct TransactionInteractionResponse: Codable {
+        public let posEntryMode: String?
+        public let posConditionCode: String?
+        public let posData: String?
+        public let cardholderAuthenticationMethod: String?
+        public let authorizationCharacteristicsIndicator: String?
+        public let cardholderAuthenticationEntity: String?
+        public let hostPosConditionCode: String?
+        public let additionalPosInformation: AdditionalPosInformationResponse?
+        public let cardPresentIndicator: String?
+        public let cardPresentAtPosIndicator: String?
+    }
+    
+    public struct TransactionDetailsResponse: Codable {
+        public let captureFlag: Bool?
+        public let transactionCaptureType: String?
+        public let authentication3DS: Bool?
+        public let processingCode: String?
+        public let merchantTransactionId: String?
+        public let merchantOrderId: String?
+        public let merchantInvoiceNumber: String?
+        public let createToken: Bool?
+        public let retrievalReferenceNumber: String?
+    }
+    
+    public struct BillingAddressResponse: Codable {
+        public let firstName: String?
+        public let lastName: String?
+    }
+    
+    public struct AvsCodeResponse: Codable {
+        public let avsCode: String?
+    }
+    
+    public struct AvsSecurityCodeResponse: Codable {
+        public let streetMatch: String?
+        public let postalCodeMatch: String?
+        public let securityCodeMatch: String?
+        public let association: AvsCodeResponse?
+    }
+    
+    public struct BankAssociationDetailsResponse: Codable {
+        public let associationResponseCode: String?
+        public let avsSecurityCodeResponse: AvsSecurityCodeResponse?
+    }
+    
+    public struct AdditionalInfoResponse: Codable {
+        public let name: String?
+        public let value: String?
+    }
+
+    public struct AccountVerificationResponse: Codable {
+        public let gatewayResponse: GatewayResponse?
+        public let processorResponseDetails: ProcessorResponseDetailsResponse?
+        public let source: SourceResponse?
+        public let billingAddress: BillingAddressResponse?
+        public let transactionDetails: TransactionDetailsResponse?
+        public let transactionInteraction: TransactionInteractionResponse?
+        public let merchantDetails: MerchantDetailsResponse?
+        public let paymentTokens: [PaymentTokenResponse]?
+        
+        public let error: ServerErrorResponse?
+    }
+    
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // TOKENIZE REQUEST
+    
+    public struct TokenizeCardRequest: Codable {
+        public let source: SourceRequest
+        public let transactionDetails: TransactionDetailsRequest
+        public let merchantDetails: MerchantDetailsRequest
+        
+        public init(source: SourceRequest,
+                    transactionDetails: TransactionDetailsRequest,
+                    merchantDetails: MerchantDetailsRequest) {
+            
+            self.source = source
+            self.transactionDetails = transactionDetails
+            self.merchantDetails = merchantDetails
+        }
+    }
+    
+    // TOKENIZE RESPONSE
+    
+    public struct PaymentTokenResponse: Codable {
+        public let tokenData: String?
+        public let tokenSource: String?
+        public let tokenResponseCode: String?
+        public let tokenResponseDescription: String?
+    }
+    
+    public struct TokenizeCardResponse: Codable {
+        public let gatewayResponse: GatewayResponse?
+        public let source: SourceResponse?
+        public let paymentTokens: [PaymentTokenResponse]?
+        public let cardDetails: CardDetailsResponse?
+        public let processorResponseDetails: ProcessorResponseDetailsResponse?
+        public let error: ServerErrorResponse?
+    }
+    
+    public struct AdditionalDataCommonProcessorRequest: Codable {
+        public let processorName: String
+        public let processingPlatform: String
+        public let settlementPlatform: String
+        public let priority: String
+        
+        public init(processorName: String,
+                    processingPlatform: String,
+                    settlementPlatform: String,
+                    priority: String) {
+            
+            self.processorName = processorName
+            self.processingPlatform = processingPlatform
+            self.settlementPlatform = settlementPlatform
+            self.priority = priority
+        }
+    }
+    
+    public struct AdditionalDataCommonProcessorsRequest: Codable {
+        public let processors: AdditionalDataCommonProcessorRequest
+        
+        public init(processors: AdditionalDataCommonProcessorRequest) {
+            self.processors = processors
+        }
+    }
+
+    public struct AdditionalDataCommonRequest: Codable {
+        public let origin: AdditionalDataCommonProcessorsRequest
+        
+        public init(origin: AdditionalDataCommonProcessorsRequest) {
+            self.origin = origin
+        }
+    }
+    
+    public struct AmountRequest: Codable {
+        public let total: Decimal
+        public let currency: String
+        
+        public init(total: Decimal,
+                    currency: String) {
+            
+            self.total = total
+            self.currency = currency
+        }
+    }
+    
+    public struct PaymentTokenCardRequest: Codable {
+        public let expirationMonth: String
+        public let expirationYear: String
+        
+        public init(expirationMonth: String, expirationYear: String) {
+            self.expirationMonth = expirationMonth
+            self.expirationYear = expirationYear
+        }
+    }
+    
+    public struct PaymentTokenSourceRequest: Codable {
+        public let sourceType: String
+        public let tokenData:String
+        public let tokenSource: String
+        public let declineDuplicates: Bool
+        public let card: PaymentTokenCardRequest
+        
+        public init(sourceType: String,
+                    tokenData: String,
+                    tokenSource: String,
+                    declineDuplicates: Bool,
+                    card: PaymentTokenCardRequest) {
+            
+            self.sourceType = sourceType
+            self.tokenData = tokenData
+            self.tokenSource = tokenSource
+            self.declineDuplicates = declineDuplicates
+            self.card = card
+        }
+    }
+    
+    public struct PaymentTokenChargeRequest: Codable {
+        public let amount: Models.AmountRequest
+        public let source: Models.PaymentTokenSourceRequest?
+        public let transactionDetails: Models.TransactionDetailsRequest
+        public let transactionInteraction: Models.TransactionInteractionRequest
+        public let merchantDetails: Models.MerchantDetailsRequest
+        
+        public init(amount: Models.AmountRequest,
+                    source: Models.PaymentTokenSourceRequest?,
+                    transactionDetails: Models.TransactionDetailsRequest,
+                    transactionInteraction: Models.TransactionInteractionRequest,
+                    merchantDetails: Models.MerchantDetailsRequest) {
+            
+            self.amount = amount
+            self.source = source
+            self.transactionDetails = transactionDetails
+            self.transactionInteraction = transactionInteraction
+            self.merchantDetails = merchantDetails
+        }
+    }
+
+    public struct ChargesRequest: Codable {
+        public let amount: Models.AmountRequest
+        public let source: Models.SourceRequest?
+        public let merchantDetails: Models.MerchantDetailsRequest
+        public let transactionDetails: Models.TransactionDetailsRequest
+        public let referenceTransactionDetails: Models.ReferenceTransactionDetailsRequest?
+        public let transactionInteraction: Models.TransactionInteractionRequest?
+        public let additionalDataCommon: AdditionalDataCommonRequest?
+        
+        public init(amount: Models.AmountRequest,
+                    source: Models.SourceRequest?,
+                    merchantDetails: Models.MerchantDetailsRequest,
+                    transactionDetails: Models.TransactionDetailsRequest,
+                    referenceTransactionDetails: Models.ReferenceTransactionDetailsRequest?,
+                    transactionInteraction: Models.TransactionInteractionRequest?,
+                    additionalDataCommon: AdditionalDataCommonRequest?) {
+            
+            self.amount = amount
+            self.source = source
+            self.merchantDetails = merchantDetails
+            self.transactionDetails = transactionDetails
+            self.referenceTransactionDetails = referenceTransactionDetails
+            self.transactionInteraction = transactionInteraction
+            self.additionalDataCommon = additionalDataCommon
+        }
+    }
+    
+    public struct CommerceHubResponse: Codable {
+        public let gatewayResponse: GatewayResponse?
+        public let source: SourceResponse?
+        public let paymentReceipt: PaymentReceiptResponse?
+        public let transactionDetails: TransactionDetailsResponse?
+        public let transactionInteraction: TransactionInteractionResponse?
+        public let merchantDetails: MerchantDetailsResponse?
+        public let networkDetails: NetworkDetailsResponse?
+        public let cardDetails: CardDetailsResponse?
+        public let paymentTokens: [PaymentTokenResponse]?
+        public let error: ServerErrorResponse?
+    }
+
+    public struct CancelsRequest: Codable {
+        public let amount: Models.AmountRequest
+        public let merchantDetails: Models.MerchantDetailsRequest
+        public let referenceTransactionDetails: Models.ReferenceTransactionDetailsRequest
+        
+        public init(amount: Models.AmountRequest,
+                    merchantDetails: Models.MerchantDetailsRequest,
+                    referenceTransactionDetails: Models.ReferenceTransactionDetailsRequest) {
+            
+            self.amount = amount
+            self.merchantDetails = merchantDetails
+            self.referenceTransactionDetails = referenceTransactionDetails
+        }
+    }
+    
+    public struct RefundsRequest: Codable {
+        public let amount: Models.AmountRequest
+        public let source: Models.SourceRequest?
+        public let merchantDetails: Models.MerchantDetailsRequest
+        public let transactionDetails: Models.TransactionDetailsRequest?
+        public let referenceTransactionDetails: Models.ReferenceTransactionDetailsRequest?
+        public let transactionInteraction: Models.TransactionInteractionRequest?
+        public let additionalDataCommon: AdditionalDataCommonRequest?
+        
+        public init(amount: Models.AmountRequest,
+                    source: Models.SourceRequest?,
+                    merchantDetails: Models.MerchantDetailsRequest,
+                    transactionDetails: Models.TransactionDetailsRequest?,
+                    referenceTransactionDetails: Models.ReferenceTransactionDetailsRequest?,
+                    transactionInteraction: Models.TransactionInteractionRequest?,
+                    additionalDataCommon: AdditionalDataCommonRequest?) {
+            
+            self.amount = amount
+            self.source = source
+            self.merchantDetails = merchantDetails
+            self.transactionDetails = transactionDetails
+            self.referenceTransactionDetails = referenceTransactionDetails
+            self.transactionInteraction = transactionInteraction
+            self.additionalDataCommon = additionalDataCommon
+        }
+    }
+    
+    public struct ApprovedAmountResponse: Codable {
+        public let total: Decimal?
+        public let currency: String?
+    }
+    
+    public struct ProcessorResponseIndicatorsResponse: Codable {
+        public let alternateRouteDebitIndicator: Bool?
+        public let signatureLineIndicator: Bool?
+        public let signatureDebitRouteIndicator: Bool?
+    }
+    
+    public struct ProcessorResponseDetailsResponse: Codable {
+        public let approvalStatus: String?
+        public let approvalCode: String?
+        public let referenceNumber: String?
+        public let processor: String?
+        public let host: String?
+        public let networkRouted: String?
+        public let networkInternationalId: String?
+        public let responseCode: String?
+        public let responseMessage: String?
+        public let hostResponseCode: String?
+        public let hostResponseMessage: String?
+        public let responseIndicators: ProcessorResponseIndicatorsResponse?
+        public let bankAssociationDetails: BankAssociationDetailsResponse?
+        public let additionalInfo: [AdditionalInfoResponse]?
+    }
+    
+    public struct PaymentReceiptResponse: Codable {
+        public let approvedAmount: ApprovedAmountResponse?
+        public let processorResponseDetails: ProcessorResponseDetailsResponse?
+    }
+    
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // TRANSACTION INQUIRY REQUEST
+    public struct TransactionInquiryRequest: Codable {
+        public let referenceTransactionDetails: ReferenceTransactionDetailsRequest
+        public let merchantDetails: MerchantDetailsRequest
+        
+        public init(referenceTransactionDetails: ReferenceTransactionDetailsRequest,
+                    merchantDetails: MerchantDetailsRequest) {
+            
+            self.referenceTransactionDetails = referenceTransactionDetails
+            self.merchantDetails = merchantDetails
+        }
+    }
+    
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // INQUIRY RESPONSE
+    
+    public struct ErrorResponse: Codable {
+        public let type: String?
+        public let field: String?
+        public let code: String?
+        public let message: String?
+    }
+    
+    public struct ServerErrorResponse: Codable {
+        public let gatewayResponse: GatewayErrorResponse
+        public let error: [ErrorResponse]?
+    }
+
+    public struct GatewayErrorResponse: Codable {
+        public let transactionType: String?
+        public let transactionState: String?
+        public let transactionProcessingDetails: TransactionProcessingDetailsResponse?
+    }
+
+    public struct DebitPinlessIndicatorResponse: Codable {
+        public let debitNetworkId: String?
+        public let pinnedPOS: String?
+    }
+    
+    public struct CardDetailsResponse: Codable {
+        public let binSource: String?
+        public let recordType: String?
+        public let lowBin: String?
+        public let highBin: String?
+        public let binLength: String?
+        public let binDetailPan: String?
+        public let issuerBankName: String?
+        public let countryCode: String?
+        public let detailedCardProduct: String?
+        public let detailedCardIndicator: String?
+        public let pinSignatureCapability: String?
+        public let issuerUpdateYear: String?
+        public let issuerUpdateMonth: String?
+        public let issuerUpdateDay: String?
+        public let regulatorIndicator: String?
+        public let cardClass: String?
+        public let debitPinlessIndicator: [DebitPinlessIndicatorResponse]?
+        public let nonMoneyTransferOCTsDomestic: String?
+        public let nonMoneyTransferOCTsCrossBorder: String?
+        public let onlineGamblingOCTsDomestic: String?
+        public let onlineGamblingOCTsCrossBorder: String?
+        public let moneyTransferOCTsDomestic: String?
+        public let moneyTransferOCTsCrossBorder: String?
+        public let fastFundsDomesticMoneyTransfer: String?
+        public let fastFundsCrossBorderMoneyTransfer: String?
+        public let fastFundsDomesticNonMoneyTransfer: String?
+        public let fastFundsCrossBorderNonMoneyTransfer: String?
+        public let fastFundsDomesticGambling: String?
+        public let fastFundsCrossBorderGambling: String?
+        public let productId: String?
+        public let accountFundSource: String?
+        public let panLengthMin: String?
+        public let panLengthMax: String?
+    }
+    
+    public struct NetworkResponse: Codable {
+        public let network: String?
+        public let cardAuthenticationResultCode: String?
+    }
+    
+    public struct NetworkDetailsResponse: Codable {
+        public let network: NetworkResponse?
+        public let debitNetworkId: String?
+        public let networkResponseCode: String?
+        public let cardLevelResultCode: String?
+        public let validationCode: String?
+        public let transactionIdentifier: String?
+    }
+    
+    public struct InquireResponse: Codable {
+        public let gatewayResponse: GatewayResponse?
+        public let source: SourceResponse?
+        public let paymentReceipt: PaymentReceiptResponse?
+        public let transactionDetails: TransactionDetailsResponse?
+        public let transactionInteraction: TransactionInteractionResponse?
+        public let merchantDetails: MerchantDetailsResponse?
+        public let networkDetails: NetworkDetailsResponse?
+        public let cardDetails: CardDetailsResponse?
+        public let paymentTokens: [PaymentTokenResponse]?
+        public let error: ServerErrorResponse?
+    }
+}
+
+extension Models.ApprovedAmountResponse {
+
+    enum CodingKeys: String, CodingKey {
+        case total = "total"
+        case currency = "currency"
+    }
+
+    public init(from decoder: Decoder) throws {
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.total = try container.decode(Double.self, forKey: .total).decimal ?? .zero
+
+        self.currency = try container.decode(String.self, forKey: .currency)
+    }
+}

--- a/Sources/FiservTTP/FiservTTP.h
+++ b/Sources/FiservTTP/FiservTTP.h
@@ -1,6 +1,6 @@
 //  FiservTTP.h
 //
-//  Copyright (c) 2022 - 2023 Fiserv, Inc.
+//  Copyright (c) 2022 - 2025 Fiserv, Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/FiservTTP/FiservTTPCardReader.swift
+++ b/Sources/FiservTTP/FiservTTPCardReader.swift
@@ -1,6 +1,6 @@
 //  FiservTTP
 //
-//  Copyright (c) 2022 - 2023 Fiserv, Inc.
+//  Copyright (c) 2022 - 2025 Fiserv, Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,49 @@
 import Foundation
 import Combine
 import ProximityReader
+
+public enum PaymentTransactionType {
+    case sale
+    case auth
+    case capture
+    case paymentToken
+}
+
+extension PaymentTransactionType: CustomStringConvertible {
+    
+    public var description: String {
+        switch self {
+        case .sale:
+            return "sale"
+        case .auth:
+            return "auth"
+        case .capture:
+            return "capture"
+        case .paymentToken:
+            return "paymentToken"
+        }
+    }
+}
+
+public enum RefundTransactionType {
+    case matched
+    case unmatched
+    case open
+}
+
+extension RefundTransactionType: CustomStringConvertible {
+    
+    public var description: String {
+        switch self {
+        case .open:
+            return "open"
+        case .matched:
+            return "tagged"
+        case .unmatched:
+            return "unmatched"
+        }
+    }
+}
 
 public struct FiservTTPCardReaderError: Error {
     
@@ -225,14 +268,531 @@ public class FiservTTPCardReader {
         
         let title = "Validate Payment Card"
         
-        guard let readerIdentifier = try await self.fiservTTPReader.readerIdentifier() else {
-            
+        guard let _ = try await self.fiservTTPReader.readerIdentifier() else {
+                    
             throw FiservTTPCardReaderError(title: title,
                                            localizedDescription: NSLocalizedString("Payment Card Reader not identified.", comment: ""))
         }
         
         return try await self.fiservTTPReader.validateCard(currencyCode: self.configuration.currencyCode)
         
+    }
+    
+    
+    /// Use this method to perform an **Account Verification**. This will check the validity and respond if an account is valid or not
+    ///
+    /// - Parameters:
+    ///   - Models.TransactionDetailsRequest
+    ///   - Models.BillingAddressRequest
+    ///
+    /// - Returns:Models.AccountVerificationResponse
+    ///
+    /// - Throws: An error of type FiservTTPCardReaderError
+    ///
+    /// - SeeAlso: [Commerce Hub Verification](https://developer.fiserv.com/product/CommerceHub/api/?type=post&path=/payments-vas/v1/accounts/verification&branch=main&version=1.24.09)
+    ///
+    public func accountVerification(transactionDetailsRequest: Models.TransactionDetailsRequest,
+                                    paymentTokenSourceRequest: Models.PaymentTokenSourceRequest? = nil,
+                                        billingAddressRequest: Models.BillingAddressRequest? = nil) async throws -> Models.AccountVerificationResponse {
+        
+        let title = "Account Verification"
+        
+        // Card Reader Identifier
+        var cardReaderIdentifier: String?
+        
+        // Card Verification
+        var cardVerificationResponse: Models.CardVerificationResponse?
+        
+        // Support Account Verification using Payment Token - nil Payment Token requires card read
+        if paymentTokenSourceRequest == nil {
+            
+            // Confirm Card Reader Identifier
+            guard let readerIdentifier = try await self.fiservTTPReader.readerIdentifier() else {
+                        
+                throw FiservTTPCardReaderError(title: title,
+                                               localizedDescription: NSLocalizedString("Payment Card Reader not identified.", comment: ""))
+            }
+            
+            cardReaderIdentifier = readerIdentifier
+            
+            // Read Card
+            let response = try await self.fiservTTPReader.validateCard(currencyCode: self.configuration.currencyCode, reason: .lookUp)
+            
+            guard let generalCardData = response.generalCardData, let paymentCardData = response.paymentCardData else {
+            
+                throw FiservTTPCardReaderError(title: title,
+                                               localizedDescription: NSLocalizedString("Payment Card data missing or corrupt.", comment: ""))
+            }
+            
+            cardVerificationResponse = Models.CardVerificationResponse(cardReaderId: readerIdentifier,
+                                                                      transactionId: response.id,
+                                                                    generalCardData: generalCardData,
+                                                                    paymentCardData: paymentCardData)
+        }
+        
+        let accountVerificationResult = await services.accountVerification(transactionDetails: transactionDetailsRequest,
+                                                                           billingAddress: billingAddressRequest,
+                                                                           paymentCardReaderId: cardReaderIdentifier,
+                                                                           paymentTokenSourceRequest: paymentTokenSourceRequest,
+                                                                           cardVerificationResponse: cardVerificationResponse)
+
+        switch accountVerificationResult {
+    
+        case .success(let response):
+            
+            let sourceResponse = appendGeneralCardDataToSourceResponse(generalCardData: cardVerificationResponse?.generalCardData,
+                                                                       response: response.source)
+            
+            let appendedResponse = Models.AccountVerificationResponse(gatewayResponse: response.gatewayResponse,
+                                                                      processorResponseDetails: response.processorResponseDetails,
+                                                                      source: sourceResponse,
+                                                                      billingAddress: response.billingAddress,
+                                                                      transactionDetails: response.transactionDetails,
+                                                                      transactionInteraction: response.transactionInteraction,
+                                                                      merchantDetails: response.merchantDetails,
+                                                                      paymentTokens: response.paymentTokens,
+                                                                      error: response.error)
+            return appendedResponse
+    
+        case .failure(let err):
+
+            throw FiservTTPCardReaderError(title: title,
+                                           localizedDescription: err.errorDescription ?? "",
+                                           failureReason: err.failureReason)
+        }
+    }
+    
+    /// Use this payload to create a **Payment token** from a payment source.
+    ///
+    /// - Parameters:
+    ///    - Models.TransactionDetailsRequest
+    ///
+    /// - Returns: Models.TokenizeCardResponse
+    ///
+    /// - Throws: An error of type FiservTTPCardReaderError
+    ///
+    /// - SeeAlso: [Commerce Hub Tokenization](https://developer.fiserv.com/product/CommerceHub/api/?type=post&path=/payments-vas/v1/tokens&branch=main&version=1.24.09)
+    ///
+    public func tokenizeCard(transactionDetailsRequest: Models.TransactionDetailsRequest) async throws -> Models.TokenizeCardResponse {
+        
+        let title = "Tokenize Card"
+        
+        guard let readerIdentifier = try await self.fiservTTPReader.readerIdentifier() else {
+                    
+            throw FiservTTPCardReaderError(title: title,
+                                           localizedDescription: NSLocalizedString("Payment Card Reader not identified.", comment: ""))
+        }
+        
+        let response = try await self.fiservTTPReader.validateCard(currencyCode: self.configuration.currencyCode,
+                                                                               reason: .lookUp)
+        
+        guard let generalCardData = response.generalCardData, let paymentCardData = response.paymentCardData else {
+        
+            throw FiservTTPCardReaderError(title: title,
+                                           localizedDescription: NSLocalizedString("Payment Card data missing or corrupt.", comment: ""))
+        }
+        
+        let verificationResponse = Models.CardVerificationResponse(cardReaderId: readerIdentifier,
+                                                                   transactionId: response.id,
+                                                                   generalCardData: generalCardData,
+                                                                   paymentCardData: paymentCardData)
+        
+        let tokenizeResult = await services.tokenize(transationDetails: transactionDetailsRequest,
+                                                     cardVerificationResponse: verificationResponse)
+    
+        switch tokenizeResult {
+    
+        case .success(let response):
+            
+            let sourceResponse = appendGeneralCardDataToSourceResponse(generalCardData: generalCardData,
+                                                                       response: response.source)
+            
+            let appendedResponse = Models.TokenizeCardResponse(gatewayResponse: response.gatewayResponse,
+                                                               source: sourceResponse,
+                                                               paymentTokens: response.paymentTokens,
+                                                               cardDetails: response.cardDetails,
+                                                               processorResponseDetails: response.processorResponseDetails,
+                                                               error: response.error)
+            return appendedResponse
+    
+        case .failure(let err):
+            
+            throw FiservTTPCardReaderError(title: title,
+                                           localizedDescription: err.errorDescription ?? "",
+                                           failureReason: err.failureReason)
+        }
+    }
+    
+    /// Use this method to return a **Commerce Hub transaction(s)** and their attributes based on order identifier.
+    ///
+    /// - Parameters:
+    ///    - Models.ReferenceTransactionDetailsRequest
+    ///
+    /// - Returns: Models.InquireResponse
+    ///
+    /// - Throws: An error of type FiservTTPCardReaderError
+    ///
+    /// - SeeAlso: [Commerce Hub Inquiry](https://developer.fiserv.com/product/CommerceHub/api/?type=post&path=/payments/v1/transaction-inquiry&branch=main&version=1.24.09)
+    ///
+    public func transactionInquiry(referenceTransactionDetailsRequest: Models.ReferenceTransactionDetailsRequest) async throws -> [Models.InquireResponse] {
+        
+        let title = "Transaction Inquiry"
+        
+        let merchantDetails = Models.MerchantDetailsRequest(merchantId: self.configuration.merchantId,
+                                                            terminalId: self.configuration.terminalId)
+        
+        let inquireRequest = Models.TransactionInquiryRequest(referenceTransactionDetails: referenceTransactionDetailsRequest,
+                                                              merchantDetails: merchantDetails)
+        
+        let inquireResult = await services.transactionInquiry(inquireRequest: inquireRequest)
+        
+        switch inquireResult {
+            
+        case .success(let response):
+            
+            return response
+            
+        case .failure(let err):
+            
+            throw FiservTTPCardReaderError(title: title,
+                                           localizedDescription: err.localizedDescription,
+                                           failureReason: err.failureReason)
+        }
+    }
+
+    // TRANS TYPE           CAP FLAG        READ CARD       CREATE TOKEN
+    //
+    // USE PAY_TOKEN        TRUE            FALSE           FALSE
+    //
+    // AUTH                 FALSE           TRUE            FALSE
+    //
+    // CAPTURE              TRUE            FALSE           FALSE
+    //
+    // SALE                 TRUE            TRUE            FALSE
+    
+    // ADDITIONAL
+    //
+    // AUTH + CAPTURE == SALE
+    // SALE == CURRENT SDK
+    //
+    // ARGS                            SALE     AUTH    CAPTURE   TOKEN
+    //
+    // READ CARD                        Y        Y         N        N
+    // MERCHANT DETAILS                 Y        Y         Y        Y
+    // CAPTURE FLAG                     T        F         T        T
+    // TRANSACTION DETAILS              Y        Y         Y        Y
+    // REFERENCE TRANSACTION DETAILS    N        N         O*       N
+    
+    // * OPTIONAL -> REFERENCE TRANSACTION DETAILS + CAPTURE (MUST BE FROM [PREVIOUS AUTH])
+    
+    // MERCHANT DETAILS    (merchantId, terminalId)
+    // TRANSACTION DETAILS (merchantTransactionId, merchantOrderId, captureFlag)
+    // REFERENCE TRANS DET (referenceTransactionId, referenceMerchantTransactionId, referenceOrderId, referenceMerchantOrderId, referenceClientRequestId)
+    
+    // * NOT USING Models.TransactionDetailsRequest because of captureFlag (so merchant won't make a mistake)
+    
+    /// Use this method to originate a **Financial transaction** based on the captureFlag * Pre-Auth = false * Sale = true * Capture = true with a transaction identifier
+    ///
+    /// - Parameters:
+    ///   - Amount
+    ///   - PaymentTransactionType
+    ///   - Models.TransactionDetailsRequest
+    ///   - Models.ReferenceTransactionDetailsRequest
+    ///   - Models.PaymentTokenSourceRequest
+    ///
+    /// - Returns: Models.CommerceHubResponse
+    ///
+    /// - Throws: An error of type FiservTTPCardReaderError
+    ///
+    /// - SeeAlso: [Commerce Hub Charges](https://developer.fiserv.com/product/CommerceHub/api/?type=post&path=/payments/v1/charges&branch=main&version=1.24.09)
+    ///
+    public func charges(amount: Decimal,
+                        transactionType: PaymentTransactionType,
+                        transactionDetailsRequest: Models.TransactionDetailsRequest,
+                        referenceTransactionDetailsRequest: Models.ReferenceTransactionDetailsRequest? = nil,
+                        paymentTokenSourceRequest: Models.PaymentTokenSourceRequest? = nil) async throws -> Models.CommerceHubResponse {
+                        
+        let title = "Charges"
+        
+        var cardReadResult: PaymentCardReadResult?
+        
+        var cardVerificationResponse: Models.CardVerificationResponse?
+        
+        var paymentTokenChargeRequest: Models.PaymentTokenChargeRequest?
+        
+        var requiresCardRead = false
+        
+        // AUTH using PAYMENT TOKEN - No Card Read, No Capture
+                
+        // AUTH - NO PAYMENT TOKEN
+        if paymentTokenSourceRequest == nil && transactionType == PaymentTransactionType.auth {
+            
+            // Requires CARD READ, No CAPTURE
+            requiresCardRead = true
+        }
+        
+        // SALE using PAYMENT TOKEN - No Card Read
+
+        // SALE - NO PAYMENT TOKEN
+        if paymentTokenSourceRequest == nil && transactionType == PaymentTransactionType.sale {
+            
+            requiresCardRead = true
+        }
+        
+        if transactionType != PaymentTransactionType.auth && transactionDetailsRequest.captureFlag == false {
+            
+            throw FiservTTPCardReaderError(title: title,
+                                           localizedDescription: NSLocalizedString("Invalid value for captureFlag, expected TRUE.", comment: ""))
+        }
+        
+        if transactionType == PaymentTransactionType.auth && transactionDetailsRequest.captureFlag == true {
+            
+            throw FiservTTPCardReaderError(title: title,
+                                           localizedDescription: NSLocalizedString("Invalid value for captureFlag, expected FALSE for PaymentTransactionType.auth.", comment: ""))
+        }
+        
+        // [AUTH (No Token), SALE] -> REQUIRES CARD READ
+        if requiresCardRead {
+            
+            // 1) CONFIRM CARD READER IDENTIFIER
+            guard let readerIdentifier = try await self.fiservTTPReader.readerIdentifier() else {
+                        
+                throw FiservTTPCardReaderError(title: title,
+                                               localizedDescription: NSLocalizedString("Payment Card Reader not identified.", comment: ""))
+            }
+            
+            // 2) READ CARD
+            let result = try await self.fiservTTPReader.readCard(for: amount,
+                                                                 currencyCode: self.configuration.currencyCode,
+                                                                 transactionType: .purchase,
+                                                                 eventHandler: { _ in
+            })
+            
+            // 3) GET READ RESULT
+            do {
+                cardReadResult = try result.get()
+            } catch {
+                throw FiservTTPCardReaderError(title: title, localizedDescription: error.localizedDescription)
+            }
+            
+            guard let generalCardData = cardReadResult?.generalCardData,
+                  let paymentCardData = cardReadResult?.paymentCardData,
+                  let transactionId = cardReadResult?.id else {
+            
+                throw FiservTTPCardReaderError(title: title,
+                                               localizedDescription: NSLocalizedString("Payment Card data missing or corrupt.", comment: ""))
+            }
+            
+            cardVerificationResponse = Models.CardVerificationResponse(cardReaderId: readerIdentifier,
+                                                                       transactionId: transactionId,
+                                                                       generalCardData: generalCardData,
+                                                                       paymentCardData: paymentCardData)
+        }
+        
+        // AMOUNT
+        let amountRequest = Models.AmountRequest(total: amount, currency: self.configuration.currencyCode)
+        
+        // (SALE, AUTH, CAPTURE, TOKEN)
+        let merchantDetailsRequest = Models.MerchantDetailsRequest(merchantId: self.configuration.merchantId,
+                                                                   terminalId: self.configuration.terminalId)
+        
+        if transactionType == .paymentToken || (transactionType == .auth && paymentTokenSourceRequest != nil) {
+            
+            let posFeaturesRequest = Models.PosFeaturesRequest(pinAuthenticationCapability: "UNSPECIFIED", terminalEntryCapability: "MANUAL_ONLY")
+
+            let posHardwareAndSoftwareRequest = Models.PosHardwareAndSoftwareRequest(softwareApplicationName: self.services.app_name,
+                                                                                     softwareVersionNumber: self.services.app_version,
+                                                                                     hardwareVendorIdentifier: self.services.vendorId)
+            
+            let additionalPosInformationRequest = Models.DataEntrySourceRequest(dataEntrySource: "MOBILE_TERMINAL",
+                                                                                posFeatures: posFeaturesRequest,
+                                                                                posHardwareAndSoftware: posHardwareAndSoftwareRequest)
+            
+            let transactionInteractionRequest = Models.TransactionInteractionRequest(origin: "POS",
+                                                                                     posEntryMode: "MANUAL",
+                                                                                     posConditionCode: "CARD_NOT_PRESENT_F2F",
+                                                                                     additionalPosInformation: additionalPosInformationRequest)
+            
+            paymentTokenChargeRequest = Models.PaymentTokenChargeRequest(amount: amountRequest,
+                                                                         source: paymentTokenSourceRequest,
+                                                                         transactionDetails: transactionDetailsRequest,
+                                                                         transactionInteraction: transactionInteractionRequest,
+                                                                         merchantDetails: merchantDetailsRequest)
+        }
+        
+        let chargesResponse = await self.services.charges(amountRequest: amountRequest,
+                                                          transactionDetailsRequest: transactionDetailsRequest,
+                                                          referenceTransactionDetailsRequest: referenceTransactionDetailsRequest,
+                                                          paymentTokenChargeRequest: paymentTokenChargeRequest,
+                                                          cardVerificationResponse: cardVerificationResponse)
+        
+        
+        switch chargesResponse {
+        case .success(let response):
+            if requiresCardRead {
+                let sourceResponse = appendGeneralCardDataToSourceResponse(generalCardData: cardVerificationResponse?.generalCardData,
+                                                                           response: response.source)
+                let commerceHubResponse = Models.CommerceHubResponse(gatewayResponse: response.gatewayResponse,
+                                                                     source: sourceResponse,
+                                                                     paymentReceipt: response.paymentReceipt,
+                                                                     transactionDetails: response.transactionDetails,
+                                                                     transactionInteraction: response.transactionInteraction,
+                                                                     merchantDetails: response.merchantDetails,
+                                                                     networkDetails: response.networkDetails,
+                                                                     cardDetails: response.cardDetails,
+                                                                     paymentTokens: response.paymentTokens,
+                                                                     error: response.error)
+                return commerceHubResponse
+            }
+            return response
+        case .failure(let err):
+            throw FiservTTPCardReaderError(title: title,
+                                           localizedDescription: err.localizedDescription,
+                                           failureReason: err.failureReason)
+        }
+    }
+    
+    /// Use this payload to perform a **Cancel** transaction (aka void).
+    ///
+    /// - Parameters:
+    ///   - Amount
+    ///   - Models.ReferenceTransactionDetailsRequest
+    ///
+    /// - Returns: Models.CommerceHubResponse
+    ///
+    /// - Throws: An error of type FiservTTPCardReaderError
+    ///
+    /// - SeeAlso: [Commerce Hub Cancels](https://developer.fiserv.com/product/CommerceHub/api/?type=post&path=/payments/v1/cancels&branch=main&version=1.24.09)
+    ///
+    public func cancels(amount: Decimal,
+                        referenceTransactionDetailsRequest: Models.ReferenceTransactionDetailsRequest) async throws -> Models.CommerceHubResponse {
+        
+        let title = "Cancel Transaction"
+        
+        let amountRequest = Models.AmountRequest(total: amount, currency: self.configuration.currencyCode)
+        
+        let cancelResponse = await services.cancels(amountRequest: amountRequest,
+                                                    referenceTransactionDetailsRequest: referenceTransactionDetailsRequest)
+        
+        switch cancelResponse {
+            
+        case .success(let response):
+            
+            return response
+        
+        case .failure(let err):
+            
+            throw FiservTTPCardReaderError(title: title,
+                                           localizedDescription: err.localizedDescription,
+                                           failureReason: err.failureReason)
+        }
+    }
+    
+    
+    // ARGS                            MATCHED    UNMATCHED    OPEN
+    //
+    // READ CARD                        N           Y           Y
+    // MERCHANT DETAILS                 Y           Y           Y
+    // CAPTURE FLAG                     F           T           T
+    // TRANSACTION DETAILS              N           Y           Y
+    // REFERENCE TRANSACTION DETAILS    Y           Y           N
+    
+    /// Use this payload to perform a **Refund** transaction (aka void).
+    ///
+    /// - Parameters:
+    ///   - Amount
+    ///   - RefundTransactionType
+    ///   - Models.TransactionDetailsRequest
+    ///   - Models.ReferenceTransactionDetailsRequest
+    ///
+    /// - Returns: Models.CommerceHubResponse
+    ///
+    /// - Throws: An error of type FiservTTPCardReaderError
+    ///
+    /// - SeeAlso: [Commerce Hub Refunds](https://developer.fiserv.com/product/CommerceHub/api/?type=post&path=/payments/v1/refunds&branch=main&version=1.24.09)
+    ///
+    public func refunds(amount: Decimal,
+                        refundTransactionType: RefundTransactionType,
+                        transactionDetails: Models.TransactionDetailsRequest? = nil,
+                        referenceTransactionDetails: Models.ReferenceTransactionDetailsRequest? = nil) async throws -> Models.CommerceHubResponse {
+        
+        let title = "Refunds Transaction"
+        
+        var cardReadResult: PaymentCardReadResult?
+        
+        var cardVerificationResponse: Models.CardVerificationResponse?
+        
+        let requiresCardRead = (refundTransactionType != .matched)
+        
+        if requiresCardRead {
+            
+            // 1) CONFIRM CARD READER IDENTIFIER
+            guard let readerIdentifier = try await self.fiservTTPReader.readerIdentifier() else {
+                        
+                throw FiservTTPCardReaderError(title: title,
+                                               localizedDescription: NSLocalizedString("Payment Card Reader not identified.", comment: ""))
+            }
+            
+            // 2) READ CARD
+            let result = try await self.fiservTTPReader.readCard(for: amount,
+                                                                 currencyCode: self.configuration.currencyCode,
+                                                                 transactionType: .purchase,
+                                                                 eventHandler: { _ in
+            })
+            
+            // 3) GET READ RESULT
+            do {
+                cardReadResult = try result.get()
+            } catch {
+                throw FiservTTPCardReaderError(title: title, localizedDescription: error.localizedDescription)
+            }
+        
+            guard let generalCardData = cardReadResult?.generalCardData,
+                  let paymentCardData = cardReadResult?.paymentCardData,
+                  let transactionId = cardReadResult?.id else {
+            
+                throw FiservTTPCardReaderError(title: title,
+                                               localizedDescription: NSLocalizedString("Payment Card data missing or corrupt.", comment: ""))
+            }
+            
+            cardVerificationResponse = Models.CardVerificationResponse(cardReaderId: readerIdentifier,
+                                                                       transactionId: transactionId,
+                                                                       generalCardData: generalCardData,
+                                                                       paymentCardData: paymentCardData)
+        }
+        
+        let amountRequest = Models.AmountRequest(total: amount, currency: self.configuration.currencyCode)
+        
+        let refundsResponse = await self.services.refunds(amountRequest: amountRequest,
+                                                          transactionDetailsRequest: transactionDetails,
+                                                          referenceTransactionDetailsRequest: referenceTransactionDetails,
+                                                          cardVerificationResponse: cardVerificationResponse)
+        
+        switch refundsResponse {
+        case .success(let response):
+            
+            if requiresCardRead {
+                let sourceResponse = appendGeneralCardDataToSourceResponse(generalCardData: cardVerificationResponse?.generalCardData,
+                                                                           response: response.source)
+                let commerceHubResponse = Models.CommerceHubResponse(gatewayResponse: response.gatewayResponse,
+                                                                     source: sourceResponse,
+                                                                     paymentReceipt: response.paymentReceipt,
+                                                                     transactionDetails: response.transactionDetails,
+                                                                     transactionInteraction: response.transactionInteraction,
+                                                                     merchantDetails: response.merchantDetails,
+                                                                     networkDetails: response.networkDetails,
+                                                                     cardDetails: response.cardDetails,
+                                                                     paymentTokens: response.paymentTokens,
+                                                                     error: response.error)
+                return commerceHubResponse
+            }
+            
+            return response
+        case .failure(let err):
+            throw FiservTTPCardReaderError(title: title,
+                                           localizedDescription: err.localizedDescription,
+                                           failureReason: err.failureReason)
+        }
     }
     
     /// Read and processes a card for the amount provided
@@ -245,18 +805,22 @@ public class FiservTTPCardReader {
     ///
     /// - Parameter merchantTransactionId: String
     ///
+    /// - Parameter merchantInvoiceNumber: String
+    ///
     /// - Returns:FiservTTPChargeResponse
     ///
     /// - Throws: An error of type FiservTTPCardReaderError
     ///
+    @available(*, deprecated, message: "This method will not be available in future versions, use the Charges method.")
     public func readCard(amount: Decimal,
-                         merchantOrderId: String,
-                         merchantTransactionId: String) async throws -> FiservTTPChargeResponse {
+                         merchantOrderId: String? = nil,
+                         merchantTransactionId: String? = nil,
+                         merchantInvoiceNumber: String? = nil) async throws -> FiservTTPChargeResponse {
         
         let title = "Read Payment Card"
         
         guard let readerIdentifier = try await self.fiservTTPReader.readerIdentifier() else {
-            
+                    
             throw FiservTTPCardReaderError(title: title,
                                            localizedDescription: NSLocalizedString("Payment Card Reader not identified.", comment: ""))
         }
@@ -281,6 +845,7 @@ public class FiservTTPCardReader {
                                                      currencyCode: self.configuration.currencyCode,
                                                      merchantOrderId: merchantOrderId,
                                                      merchantTransactionId: merchantTransactionId,
+                                                     merchantInvoiceNumber: merchantInvoiceNumber,
                                                      paymentCardReaderId: readerIdentifier,
                                                      paymentCardReadResult: cardReadResult)
             
@@ -322,6 +887,7 @@ public class FiservTTPCardReader {
     ///
     /// - Throws: An error of type FiservTTPCardReaderError
     ///
+    @available(*, deprecated, message: "This method will not be available in future versions, use the Inquire method.")
     public func inquiryTransaction(referenceTransactionId: String? = nil,
                                    referenceMerchantTransactionId: String? = nil,
                                    referenceMerchantOrderId: String? = nil,
@@ -362,6 +928,7 @@ public class FiservTTPCardReader {
     ///
     /// - Throws: An error of type FiservTTPCardReaderError
     ///
+    @available(*, deprecated, message: "This method will not be available in future versions, use the Cancels method.")
     public func voidTransaction(amount: Decimal,
                                 referenceTransactionId: String? = nil,
                                 referenceMerchantTransactionId: String? = nil) async throws -> FiservTTPChargeResponse {
@@ -402,6 +969,7 @@ public class FiservTTPCardReader {
     ///
     /// - Throws: An error of type FiservTTPCardReaderError
     ///
+    @available(*, deprecated, message: "This method will not be available in future versions, use the Refunds method.")
     public func refundTransaction(amount: Decimal,
                                   referenceTransactionId: String? = nil,
                                   referenceMerchantTransactionId: String? = nil) async throws -> FiservTTPChargeResponse {
@@ -448,16 +1016,18 @@ public class FiservTTPCardReader {
     ///
     /// - Throws: An error of type FiservTTPCardReaderError
     ///
+    @available(*, deprecated, message: "This method will not be available in future versions, use the Refunds method.")
     public func refundCard(amount: Decimal,
                            merchantOrderId: String? = nil,
                            merchantTransactionId: String? = nil,
+                           merchantInvoiceNumber: String? = nil,
                            referenceTransactionId: String? = nil,
                            referenceMerchantTransactionId: String? = nil) async throws -> FiservTTPChargeResponse {
         
         let title = "Refund Payment Card"
         
         guard let readerIdentifier = try await self.fiservTTPReader.readerIdentifier() else {
-            
+                    
             throw FiservTTPCardReaderError(title: title,
                                            localizedDescription: NSLocalizedString("Payment Card Reader not identified.", comment: ""))
         }
@@ -480,6 +1050,7 @@ public class FiservTTPCardReader {
             
             let refundCardResult = await services.refundCard(merchantOrderId: merchantOrderId,
                                                              merchantTransactionId: merchantTransactionId,
+                                                             merchantInvoiceNumber: merchantInvoiceNumber,
                                                              referenceTransactionId: referenceTransactionId,
                                                              referenceMerchantTransactionId: referenceMerchantTransactionId,
                                                              referenceTransactionType: "CHARGES",
@@ -510,6 +1081,17 @@ public class FiservTTPCardReader {
         }
     }
     
+    private func appendGeneralCardDataToSourceResponse(generalCardData: String?, response: Models.SourceResponse?) -> Models.SourceResponse {
+        
+        let sourceResponse = Models.SourceResponse(sourceType: response?.sourceType,
+                                                   hasBeenDecrypted: response?.hasBeenDecrypted,
+                                                   card: response?.card,
+                                                   emvData: response?.emvData,
+                                                   generalCardData: base64ToHex(generalCardData))
+        
+        return sourceResponse
+    }
+    
     private func appGeneralCardData(generalCardData: String, response: FiservTTPChargeResponse) -> FiservTTPChargeResponse {
         
         let appendedResponse = FiservTTPChargeResponse(gatewayResponse: response.gatewayResponse,
@@ -529,9 +1111,9 @@ public class FiservTTPCardReader {
         return appendedResponse
     }
     
-    private func base64ToHex(_ base64String: String) -> String? {
+    private func base64ToHex(_ base64String: String?) -> String? {
         
-        guard let data = Data(base64Encoded: base64String) else {
+        guard let data = Data(base64Encoded: base64String ?? String()) else {
             return nil
         }
         

--- a/Sources/FiservTTP/FiservTTPModels.swift
+++ b/Sources/FiservTTP/FiservTTPModels.swift
@@ -1,6 +1,6 @@
 //  FiservTTP
 //
-//  Copyright (c) 2022 - 2023 Fiserv, Inc.
+//  Copyright (c) 2022 - 2025 Fiserv, Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,16 @@
 //  THE SOFTWARE.
 
 import Foundation
+
+extension Optional where Wrapped == String {
+    var nilIfEmpty: String? {
+        guard let strongSelf = self else {
+            return nil
+        }
+        let safeString = strongSelf.trimmingCharacters(in: .whitespacesAndNewlines)
+        return safeString.isEmpty ? nil : safeString
+    }
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // ERROR WRAPPER
@@ -43,14 +53,14 @@ public struct FiservTTPErrorWrapper: Identifiable {
 public struct FiservTTPResponseWrapper: Identifiable {
     public let id: UUID
     public let title: String
-    public let response: FiservTTPChargeResponse?
-    public let responses: [FiservTTPChargeResponse]?
     
-    public init(id: UUID = UUID(), title: String, response: FiservTTPChargeResponse? = nil, responses: [FiservTTPChargeResponse]? = nil) {
+    public let responseString: String?
+    
+    public init(id: UUID = UUID(), title: String, responseString: String? = nil) {
+        
         self.id = id
         self.title = title
-        self.response = response
-        self.responses = responses
+        self.responseString = responseString
     }
 }
 
@@ -101,7 +111,7 @@ public struct FiservTTPConfig {
         self.environment = environment
         self.currencyCode = currencyCode
         self.merchantId = merchantId
-        self.appleTtpMerchantId = appleTtpMerchantId
+        self.appleTtpMerchantId = appleTtpMerchantId.nilIfEmpty
         self.merchantName = merchantName
         self.merchantCategoryCode = merchantCategoryCode
         self.terminalId = terminalId
@@ -217,8 +227,9 @@ internal struct FiservTTPChargeRequestSource: Codable {
 
 internal struct FiservTTPChargeRequestTransactionDetails: Codable {
     let captureFlag: Bool
-    let merchantOrderId: String
-    let merchantTransactionId: String
+    let merchantOrderId: String?
+    let merchantTransactionId: String?
+    let merchantInvoiceNumber: String?
 }
 
 internal struct FiservTTPChargeRequestPosFeatures: Codable {
@@ -244,6 +255,7 @@ internal struct FiservTTPChargeRequestAdditionalDataCommonProcessor: Codable {
 internal struct FiservTTPChargeRequestPosHardwareAndSoftware: Codable {
     let softwareApplicationName: String
     let softwareVersionNumber: String
+    let hardwareVendorIdentifier: String
 }
 
 internal struct FiservTTPChargeRequestDataEntrySource: Codable {
@@ -393,6 +405,7 @@ internal struct FiservTTPRefundCardRequestTransactionDetails: Codable {
     let captureFlag: Bool
     let merchantOrderId: String?
     let merchantTransactionId: String?
+    let merchantInvoiceNumber: String?
 }
 
 internal struct FiservTTPRefundCardRequest: Codable {
@@ -559,6 +572,7 @@ public struct FiservTTPChargeResponseTransactionDetails: Codable {
     public let processingCode: String?
     public let merchantTransactionId: String?
     public let merchantOrderId: String?
+    public let merchantInvoiceNumber: String?
     public let createToken: Bool?
     public let retrievalReferenceNumber: String?
 }

--- a/Sources/FiservTTP/FiservTTPReader.swift
+++ b/Sources/FiservTTP/FiservTTPReader.swift
@@ -1,6 +1,6 @@
 //  FiservTTP
 //
-//  Copyright (c) 2022 - 2023 Fiserv, Inc.
+//  Copyright (c) 2022 - 2025 Fiserv, Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -180,7 +180,7 @@ internal class FiservTTPReader {
         }
     }
     
-    internal func validateCard(currencyCode: String) async throws -> FiservTTPValidateCardResponse {
+    internal func validateCard(currencyCode: String, reason: PaymentCardVerificationRequest.Reason = .other) async throws -> FiservTTPValidateCardResponse {
         
         guard let session = cardReaderSession else {
          
@@ -190,7 +190,7 @@ internal class FiservTTPReader {
         
         do {
             
-            let request = PaymentCardVerificationRequest(currencyCode: currencyCode, for: .other)
+            let request = PaymentCardVerificationRequest(currencyCode: currencyCode, for: reason)
             
             // This method throws a ReadError if a person dismisses the sheet or the sheet fails to appear.
             let result = try await session.readPaymentCard(request)


### PR DESCRIPTION
Release Notes v1.0.7

Added new Charges API which now supports supports Sale, Authorizations, Capture, Auth with PaymentTokens

Added new Cancels API

Added new Refunds API which supports Matched, Unmatched, and Open Refunds

Added new Account Verification API

Added new Tokenization API

Added new Transaction Inquiry API

The following APIs have been deprecated:

fiservTTPCardReader.readCard (Charges)

fiservTTPCardReader.inquiryTransaction (Inquiry)

fiservTTPCardReader.refundTransaction (Tagged Refund)

fiservTTPCardReader.refundCard (Unmatched Tagged Refund and Open Refund)

fiservTTPCardReader.voidTransaction (Cancel)